### PR TITLE
feat(skills): reactive snapshots, typed status, marketplace UI, soft-disabled tier, in-app editor

### DIFF
--- a/desktop/renderer/src/components/skills/IncomingPanel.tsx
+++ b/desktop/renderer/src/components/skills/IncomingPanel.tsx
@@ -1,0 +1,357 @@
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "../../lib/utils";
+import { useGatewayStore } from "../../stores/gateway-store";
+
+type IncomingSkill = {
+  name: string;
+  author_peer_id?: string;
+  timestamp?: number;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  signatureValid?: boolean;
+  injectionScan?: { severity?: string; matches?: number };
+  provenance?: Record<string, unknown>;
+  contentHash?: string;
+  expiresAt?: number;
+};
+
+type IncomingListResult = { skills?: IncomingSkill[] };
+
+function formatTimestamp(ts?: number): string {
+  if (!ts) return "—";
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return "—";
+  }
+}
+
+function shortPeer(peer?: string): string {
+  if (!peer) return "unknown peer";
+  if (peer.length <= 16) return peer;
+  return `${peer.slice(0, 8)}…${peer.slice(-6)}`;
+}
+
+function severityClass(severity?: string): string {
+  if (severity === "critical") return "bg-red-500/15 text-red-300 border-red-500/30";
+  if (severity === "high") return "bg-orange-500/15 text-orange-300 border-orange-500/30";
+  if (severity === "medium") return "bg-amber-500/15 text-amber-300 border-amber-500/30";
+  if (severity === "low") return "bg-yellow-500/10 text-yellow-300 border-yellow-500/20";
+  return "bg-zinc-500/10 text-zinc-300 border-zinc-500/20";
+}
+
+function ImportFromAgentskills() {
+  const gwStatus = useGatewayStore((s) => s.status);
+  const request = useGatewayStore((s) => s.request);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  const submit = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = (await request("skills.import.agentskills", { input: trimmed })) as {
+        ok: boolean;
+        action?: string;
+        skillName?: string;
+        reason?: string;
+      };
+      if (res.ok) {
+        setInput("");
+        setMessage({
+          kind: "ok",
+          text:
+            res.action === "accepted"
+              ? `Imported "${res.skillName}" — installed and ready to enable.`
+              : `Imported "${res.skillName}" — queued for review below.`,
+        });
+      } else {
+        setMessage({ kind: "err", text: res.reason ?? "Import failed" });
+      }
+    } catch (err) {
+      setMessage({
+        kind: "err",
+        text: err instanceof Error ? err.message : "Import failed",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [input, request]);
+
+  return (
+    <div className="p-4 rounded-lg border border-border/20 bg-card/40 space-y-2">
+      <div className="text-sm font-semibold text-foreground">Import from agentskills.io</div>
+      <p className="text-xs text-muted-foreground">
+        Paste a skill slug (e.g. <code className="text-foreground">brave-search</code>) or full
+        https URL. By default imports go through the review queue.
+      </p>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="slug or https URL"
+          disabled={busy || gwStatus !== "connected"}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              void submit();
+            }
+          }}
+          className={cn(
+            "flex-1 h-8 px-3 text-sm rounded-md border bg-transparent text-foreground",
+            "border-border/30 focus:border-purple-500 focus:outline-none",
+            busy && "opacity-50",
+          )}
+        />
+        <button
+          onClick={() => void submit()}
+          disabled={busy || !input.trim() || gwStatus !== "connected"}
+          className={cn(
+            "px-3 py-1.5 text-xs rounded-md border transition-colors",
+            "bg-purple-500/10 text-purple-300 border-purple-500/20 hover:bg-purple-500/20",
+            (busy || !input.trim()) && "opacity-50 cursor-not-allowed",
+          )}
+        >
+          {busy ? "Importing…" : "Import"}
+        </button>
+      </div>
+      {message && (
+        <div className={cn("text-xs", message.kind === "ok" ? "text-green-300" : "text-red-300")}>
+          {message.text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function IncomingPanel({
+  onCountChange,
+}: {
+  onCountChange?: (count: number) => void;
+} = {}) {
+  const gwStatus = useGatewayStore((s) => s.status);
+  const request = useGatewayStore((s) => s.request);
+  const subscribe = useGatewayStore((s) => s.subscribe);
+
+  const [items, setItems] = useState<IncomingSkill[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    onCountChange?.(items.length);
+  }, [items.length, onCountChange]);
+
+  const refresh = useCallback(async () => {
+    if (gwStatus !== "connected") return;
+    setLoading(true);
+    try {
+      const res = (await request("skills.incoming.list", {})) as IncomingListResult;
+      setItems(Array.isArray(res?.skills) ? res.skills : []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load incoming skills");
+    } finally {
+      setLoading(false);
+    }
+  }, [gwStatus, request]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    return subscribe((evt) => {
+      if (evt.event === "skills.changed") {
+        void refresh();
+      }
+    });
+  }, [subscribe, refresh]);
+
+  const accept = useCallback(
+    async (name: string) => {
+      if (
+        !confirm(
+          `Accept "${name}" into managed skills?\n\nThis copies it from quarantine. It will be installed but stay disabled until you toggle it on.`,
+        )
+      )
+        return;
+      setBusy(name);
+      try {
+        await request("skills.incoming.accept", { skillName: name });
+      } catch (err) {
+        alert(`Accept failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [request],
+  );
+
+  const reject = useCallback(
+    async (name: string) => {
+      if (!confirm(`Reject "${name}" and remove from quarantine?`)) return;
+      setBusy(name);
+      try {
+        await request("skills.incoming.reject", { skillName: name });
+      } catch (err) {
+        alert(`Reject failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [request],
+  );
+
+  const rejectByPeer = useCallback(
+    async (peer: string) => {
+      if (
+        !confirm(
+          `Reject every quarantined skill from peer ${shortPeer(peer)}?\n\nThis cannot be undone.`,
+        )
+      )
+        return;
+      setBusy(`peer:${peer}`);
+      try {
+        await request("skills.incoming.rejectByPeer", { authorPeerId: peer });
+      } catch (err) {
+        alert(`Bulk reject failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [request],
+  );
+
+  return (
+    <div className="space-y-4">
+      <ImportFromAgentskills />
+      {error && (
+        <div className="p-4 rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+      {loading && items.length === 0 && (
+        <div className="p-8 text-center text-muted-foreground text-sm">
+          Loading incoming skills…
+        </div>
+      )}
+      {!loading && items.length === 0 && !error && (
+        <div className="p-8 text-center text-muted-foreground text-sm rounded-xl border border-border/20 bg-card/60 backdrop-blur-sm">
+          No skills in quarantine. New marketplace skills appear here for review.
+        </div>
+      )}
+      {items.map((item) => {
+        const itemBusy = busy === item.name;
+        const peer = item.author_peer_id;
+        const peerBusy = peer ? busy === `peer:${peer}` : false;
+        const sigOk = item.signatureValid === true;
+        const sigBad = item.signatureValid === false;
+        const scanSeverity = item.injectionScan?.severity;
+        return (
+          <div
+            key={item.name}
+            className="p-4 rounded-lg border border-border/20 bg-card/40 space-y-2"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-semibold text-foreground">{item.name}</span>
+              {item.category && (
+                <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-300">
+                  {item.category}
+                </span>
+              )}
+              {sigOk && (
+                <span className="text-xs px-1.5 py-0.5 rounded border bg-green-500/10 text-green-300 border-green-500/20">
+                  signature ok
+                </span>
+              )}
+              {sigBad && (
+                <span className="text-xs px-1.5 py-0.5 rounded border bg-red-500/10 text-red-300 border-red-500/20">
+                  signature failed
+                </span>
+              )}
+              {scanSeverity && (
+                <span
+                  title={`Injection scan: ${scanSeverity}${
+                    item.injectionScan?.matches ? ` (${item.injectionScan.matches} matches)` : ""
+                  }`}
+                  className={cn(
+                    "text-xs px-1.5 py-0.5 rounded border",
+                    severityClass(scanSeverity),
+                  )}
+                >
+                  scan: {scanSeverity}
+                </span>
+              )}
+            </div>
+            {item.description && (
+              <p className="text-xs text-muted-foreground">{item.description}</p>
+            )}
+            <div className="text-[11px] text-muted-foreground space-y-0.5 font-mono">
+              <div>From: {shortPeer(peer)}</div>
+              <div>Received: {formatTimestamp(item.timestamp)}</div>
+              {item.contentHash && (
+                <div title={item.contentHash}>Hash: {item.contentHash.slice(0, 16)}…</div>
+              )}
+              {item.expiresAt && <div>Expires: {formatTimestamp(item.expiresAt)}</div>}
+            </div>
+            {item.tags && item.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {item.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="text-[10px] px-1 py-0.5 rounded bg-muted text-muted-foreground"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="flex flex-wrap gap-2 pt-1">
+              <button
+                onClick={() => accept(item.name)}
+                disabled={itemBusy}
+                className={cn(
+                  "px-3 py-1.5 text-xs rounded-md border transition-colors",
+                  "bg-green-500/10 text-green-300 border-green-500/20 hover:bg-green-500/20",
+                  itemBusy && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                {itemBusy ? "Working…" : "Accept"}
+              </button>
+              <button
+                onClick={() => reject(item.name)}
+                disabled={itemBusy}
+                className={cn(
+                  "px-3 py-1.5 text-xs rounded-md border transition-colors",
+                  "bg-red-500/10 text-red-300 border-red-500/20 hover:bg-red-500/20",
+                  itemBusy && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                Reject
+              </button>
+              {peer && (
+                <button
+                  onClick={() => rejectByPeer(peer)}
+                  disabled={peerBusy}
+                  title={`Reject all queued skills from ${shortPeer(peer)}`}
+                  className={cn(
+                    "px-3 py-1.5 text-xs rounded-md border transition-colors",
+                    "bg-zinc-500/10 text-zinc-300 border-zinc-500/20 hover:bg-zinc-500/20",
+                    peerBusy && "opacity-50 cursor-not-allowed",
+                  )}
+                >
+                  Reject all from peer
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/renderer/src/components/skills/SkillEditor.tsx
+++ b/desktop/renderer/src/components/skills/SkillEditor.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useMemo, useState } from "react";
+import { cn } from "../../lib/utils";
+import { useGatewayStore } from "../../stores/gateway-store";
+
+const TEMPLATES: Record<string, { label: string; content: string }> = {
+  basic: {
+    label: "Basic skill",
+    content: `---
+name: my-skill
+description: A short one-line description of what this skill does.
+emoji: 🛠️
+---
+
+## When to use
+
+Describe the situations where the agent should reach for this skill.
+
+## How it works
+
+Describe the steps, tools, or knowledge the agent should apply.
+
+## Examples
+
+- Example 1: …
+- Example 2: …
+`,
+  },
+  api: {
+    label: "API-backed skill",
+    content: `---
+name: my-api-skill
+description: Wraps an external API. Replace primaryEnv with your env var name.
+emoji: 🌐
+primaryEnv: MY_API_KEY
+requires:
+  env:
+    - MY_API_KEY
+---
+
+## When to use
+
+When the user asks for something this API provides.
+
+## API reference
+
+Explain the endpoints, parameters, and expected responses the agent
+needs to know to call this API correctly.
+`,
+  },
+  shell: {
+    label: "Shell-tool skill",
+    content: `---
+name: my-cli-skill
+description: Calls a local CLI tool. Lists required binaries.
+emoji: 🐚
+requires:
+  bins:
+    - jq
+os:
+  - darwin
+  - linux
+---
+
+## When to use
+
+When the task involves transforming JSON or invoking the listed tools.
+
+## Usage notes
+
+Document the exact commands and flags the agent should prefer.
+`,
+  },
+};
+
+export function SkillEditor({ onClose }: { onClose: () => void }) {
+  const request = useGatewayStore((s) => s.request);
+  const [templateKey, setTemplateKey] = useState<string>("basic");
+  const [name, setName] = useState("");
+  const [content, setContent] = useState(TEMPLATES.basic.content);
+  const [target, setTarget] = useState<"managed" | "workspace">("managed");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const applyTemplate = useCallback((key: string) => {
+    setTemplateKey(key);
+    const tpl = TEMPLATES[key];
+    if (tpl) setContent(tpl.content);
+  }, []);
+
+  const validation = useMemo(() => {
+    const trimmed = content.trim();
+    if (!trimmed.startsWith("---")) {
+      return { ok: false, message: "SKILL.md must start with --- (YAML frontmatter)." };
+    }
+    const end = trimmed.indexOf("\n---", 3);
+    if (end === -1) {
+      return { ok: false, message: "Frontmatter is not closed (missing trailing ---)." };
+    }
+    const fm = trimmed.slice(3, end);
+    if (!/\bname\s*:/.test(fm)) {
+      return { ok: false, message: "Frontmatter must include a 'name:' field." };
+    }
+    if (!/\bdescription\s*:/.test(fm)) {
+      return { ok: false, message: "Frontmatter must include a 'description:' field." };
+    }
+    return { ok: true as const, message: "" };
+  }, [content]);
+
+  const submit = useCallback(async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+    if (!validation.ok) {
+      setError(validation.message);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await request("skills.create", {
+        name: trimmedName,
+        content,
+        target,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [content, name, onClose, request, target, validation]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div className="w-full max-w-3xl max-h-[90vh] flex flex-col rounded-xl border border-border/30 bg-card shadow-2xl">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border/20">
+          <h2 className="text-lg font-semibold text-foreground">Create skill</h2>
+          <button
+            onClick={onClose}
+            disabled={busy}
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Close
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-5 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="space-y-1">
+              <span className="text-xs text-muted-foreground">Skill name</span>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-skill"
+                disabled={busy}
+                className={cn(
+                  "w-full h-8 px-3 text-sm rounded-md border bg-transparent text-foreground",
+                  "border-border/30 focus:border-purple-500 focus:outline-none",
+                )}
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-muted-foreground">Save to</span>
+              <select
+                value={target}
+                onChange={(e) => setTarget(e.target.value as "managed" | "workspace")}
+                disabled={busy}
+                className={cn(
+                  "w-full h-8 px-2 text-sm rounded-md border bg-transparent text-foreground",
+                  "border-border/30 focus:border-purple-500 focus:outline-none",
+                )}
+              >
+                <option value="managed">Managed (~/.bitterbot/skills)</option>
+                <option value="workspace">Workspace (current agent)</option>
+              </select>
+            </label>
+          </div>
+          <div className="space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Template</span>
+              <div className="flex gap-1">
+                {Object.entries(TEMPLATES).map(([key, tpl]) => (
+                  <button
+                    key={key}
+                    onClick={() => applyTemplate(key)}
+                    disabled={busy}
+                    className={cn(
+                      "px-2 py-0.5 text-[11px] rounded border transition-colors",
+                      key === templateKey
+                        ? "bg-purple-500/15 border-purple-500/30 text-foreground"
+                        : "border-border/30 text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {tpl.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+          <label className="space-y-1 block">
+            <span className="text-xs text-muted-foreground">SKILL.md content</span>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              disabled={busy}
+              spellCheck={false}
+              rows={20}
+              className={cn(
+                "w-full px-3 py-2 text-xs font-mono rounded-md border bg-transparent text-foreground resize-none",
+                "border-border/30 focus:border-purple-500 focus:outline-none",
+              )}
+            />
+          </label>
+          {!validation.ok && <div className="text-xs text-amber-300">{validation.message}</div>}
+          {error && <div className="text-xs text-red-300">{error}</div>}
+          <p className="text-[11px] text-muted-foreground">
+            Skills you create stay disabled until you toggle them on. The agent will automatically
+            see new skills on its next turn.
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-border/20">
+          <button
+            onClick={onClose}
+            disabled={busy}
+            className="px-3 py-1.5 text-xs rounded-md border border-border/30 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void submit()}
+            disabled={busy || !validation.ok || !name.trim()}
+            className={cn(
+              "px-3 py-1.5 text-xs rounded-md border transition-colors",
+              "bg-purple-500/15 text-purple-200 border-purple-500/30 hover:bg-purple-500/25",
+              (busy || !validation.ok || !name.trim()) && "opacity-50 cursor-not-allowed",
+            )}
+          >
+            {busy ? "Saving…" : "Save skill"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/renderer/src/components/skills/SkillsView.tsx
+++ b/desktop/renderer/src/components/skills/SkillsView.tsx
@@ -1,57 +1,190 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "../../lib/utils";
 import { useGatewayStore } from "../../stores/gateway-store";
-import { useSkillsStore, type SkillStatus } from "../../stores/skills-store";
+import {
+  type SkillInstallOption,
+  type SkillOrigin,
+  type SkillState,
+  type SkillStatus,
+  useSkillsStore,
+} from "../../stores/skills-store";
+import { IncomingPanel } from "./IncomingPanel";
+import { SkillEditor } from "./SkillEditor";
+
+type RawSkillEntry = {
+  skillKey?: string;
+  name?: string;
+  description?: string;
+  source?: string;
+  disabled?: boolean;
+  eligible?: boolean;
+  primaryEnv?: string;
+  requirements?: { bins?: string[] };
+  install?: SkillInstallOption[];
+  state?: SkillState;
+  reasons?: string[];
+  platformLabel?: string;
+  hasApiKey?: boolean;
+  origin?: SkillOrigin;
+};
 
 type SkillReport = {
-  skills?: Array<{
-    key: string;
-    name: string;
-    description?: string;
-    category?: string;
-    enabled: boolean;
-    installed: boolean;
-    hasApiKey?: boolean;
-    requires?: { bins?: string[] };
-    metadata?: Record<string, unknown>;
-  }>;
+  skills?: RawSkillEntry[];
   [key: string]: unknown;
 };
+
+const VALID_STATES: ReadonlySet<SkillState> = new Set([
+  "ready",
+  "disabled-by-user",
+  "missing-os",
+  "missing-bin",
+  "missing-env",
+  "missing-config",
+  "blocked-by-allowlist",
+]);
+
+function normalizeSkill(raw: RawSkillEntry): SkillStatus | null {
+  const key = typeof raw.skillKey === "string" ? raw.skillKey : "";
+  const name = typeof raw.name === "string" ? raw.name : "";
+  if (!key) return null;
+  const declaredState = raw.state && VALID_STATES.has(raw.state) ? raw.state : undefined;
+  const fallbackState: SkillState =
+    raw.disabled === true ? "disabled-by-user" : raw.eligible ? "ready" : "missing-bin";
+  return {
+    key,
+    name: name || key,
+    description: raw.description,
+    category: raw.source,
+    enabled: raw.disabled !== true,
+    installed: raw.eligible === true,
+    hasApiKey: raw.hasApiKey === true,
+    state: declaredState ?? fallbackState,
+    reasons: Array.isArray(raw.reasons) ? raw.reasons : [],
+    platformLabel: raw.platformLabel,
+    primaryEnv: raw.primaryEnv,
+    requires: raw.requirements?.bins?.length ? { bins: raw.requirements.bins } : undefined,
+    install: Array.isArray(raw.install) ? raw.install : undefined,
+    origin: raw.origin,
+  };
+}
+
+type StateAppearance = {
+  label: string;
+  className: string;
+};
+
+const STATE_APPEARANCE: Record<SkillState, StateAppearance> = {
+  ready: { label: "Ready", className: "bg-green-500/10 text-green-300 border-green-500/20" },
+  "disabled-by-user": {
+    label: "Disabled",
+    className: "bg-zinc-500/10 text-zinc-300 border-zinc-500/20",
+  },
+  "missing-os": {
+    label: "Incompatible OS",
+    className: "bg-red-500/10 text-red-300 border-red-500/20",
+  },
+  "missing-bin": {
+    label: "Needs install",
+    className: "bg-amber-500/10 text-amber-300 border-amber-500/20",
+  },
+  "missing-env": {
+    label: "Needs API key",
+    className: "bg-amber-500/10 text-amber-300 border-amber-500/20",
+  },
+  "missing-config": {
+    label: "Needs config",
+    className: "bg-amber-500/10 text-amber-300 border-amber-500/20",
+  },
+  "blocked-by-allowlist": {
+    label: "Allowlisted off",
+    className: "bg-zinc-500/10 text-zinc-300 border-zinc-500/20",
+  },
+};
+
+type FilterTab = "all" | "ready" | "disabled" | "needs-setup" | "incompatible";
+
+const NEEDS_SETUP_STATES: ReadonlySet<SkillState> = new Set([
+  "missing-bin",
+  "missing-env",
+  "missing-config",
+]);
+
+function matchesTab(skill: SkillStatus, tab: FilterTab): boolean {
+  switch (tab) {
+    case "all":
+      return skill.state !== "missing-os";
+    case "ready":
+      return skill.state === "ready";
+    case "disabled":
+      return skill.state === "disabled-by-user" || skill.state === "blocked-by-allowlist";
+    case "needs-setup":
+      return NEEDS_SETUP_STATES.has(skill.state);
+    case "incompatible":
+      return skill.state === "missing-os";
+  }
+}
+
+function StateBadge({ state, reasons }: { state: SkillState; reasons: string[] }) {
+  const appearance = STATE_APPEARANCE[state];
+  const tooltip = reasons.length > 0 ? reasons.join(" ") : appearance.label;
+  return (
+    <span
+      title={tooltip}
+      className={cn("text-xs px-1.5 py-0.5 rounded border", appearance.className)}
+    >
+      {appearance.label}
+    </span>
+  );
+}
 
 function SkillCard({
   skill,
   onToggle,
+  onInstall,
+  installing,
 }: {
   skill: SkillStatus;
   onToggle: (key: string, enabled: boolean) => void;
+  onInstall: (skill: SkillStatus) => void;
+  installing: boolean;
 }) {
+  const isHardDisabled = skill.state === "missing-os" || skill.state === "blocked-by-allowlist";
+  const showInstall = skill.state === "missing-bin" && (skill.install?.length ?? 0) > 0;
   return (
     <div className="flex items-start gap-3 px-4 py-3 rounded-lg bg-card/40 border border-border/10">
       <button
-        onClick={() => onToggle(skill.key, !skill.enabled)}
+        onClick={() => !isHardDisabled && onToggle(skill.key, !skill.enabled)}
+        disabled={isHardDisabled}
+        title={
+          isHardDisabled
+            ? skill.reasons.join(" ") || "Cannot enable on this system"
+            : skill.enabled
+              ? "Disable"
+              : "Enable"
+        }
         className={cn(
           "mt-0.5 w-9 h-5 rounded-full transition-colors relative flex-shrink-0",
-          skill.enabled ? "bg-purple-500" : "bg-muted",
+          skill.enabled && !isHardDisabled ? "bg-purple-500" : "bg-muted",
+          isHardDisabled && "opacity-40 cursor-not-allowed",
         )}
       >
         <span
           className={cn(
             "absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform",
-            skill.enabled ? "left-[18px]" : "left-0.5",
+            skill.enabled && !isHardDisabled ? "left-[18px]" : "left-0.5",
           )}
         />
       </button>
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm font-medium text-foreground">{skill.name}</span>
-          {skill.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-300">
-              {skill.category}
-            </span>
-          )}
-          {!skill.installed && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-400">
-              not installed
+          <StateBadge state={skill.state} reasons={skill.reasons} />
+          {skill.platformLabel && skill.state !== "missing-os" && (
+            <span
+              title={`Declared platform support: ${skill.platformLabel}`}
+              className="text-xs px-1.5 py-0.5 rounded border bg-blue-500/10 text-blue-300 border-blue-500/20"
+            >
+              {skill.platformLabel}
             </span>
           )}
           {skill.hasApiKey && (
@@ -59,12 +192,17 @@ function SkillCard({
               API key set
             </span>
           )}
+          {skill.category && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-300">
+              {skill.category}
+            </span>
+          )}
         </div>
         {skill.description && (
           <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{skill.description}</p>
         )}
         {skill.requires?.bins && skill.requires.bins.length > 0 && (
-          <div className="flex gap-1 mt-1">
+          <div className="flex flex-wrap gap-1 mt-1">
             {skill.requires.bins.map((bin) => (
               <span
                 key={bin}
@@ -75,14 +213,141 @@ function SkillCard({
             ))}
           </div>
         )}
+        {skill.origin?.registry && (
+          <div className="text-[10px] text-muted-foreground mt-1 flex flex-wrap gap-x-2">
+            <span title="Registry the skill was imported from">
+              from <span className="text-foreground/80">{skill.origin.registry}</span>
+            </span>
+            {skill.origin.slug && <span>· slug {skill.origin.slug}</span>}
+            {skill.origin.version && <span>· v{skill.origin.version}</span>}
+            {skill.origin.license && <span>· {skill.origin.license}</span>}
+            {skill.origin.upstreamUrl && (
+              <a
+                href={skill.origin.upstreamUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-purple-300 hover:underline"
+              >
+                upstream
+              </a>
+            )}
+          </div>
+        )}
+        {showInstall && (
+          <button
+            onClick={() => onInstall(skill)}
+            disabled={installing}
+            className={cn(
+              "mt-2 px-2 py-1 text-xs rounded-md border transition-colors",
+              "bg-amber-500/10 text-amber-300 border-amber-500/20 hover:bg-amber-500/20",
+              installing && "opacity-50 cursor-not-allowed",
+            )}
+          >
+            {installing ? "Installing…" : (skill.install?.[0]?.label ?? "Install dependency")}
+          </button>
+        )}
       </div>
     </div>
   );
 }
 
+const TABS: Array<{ id: FilterTab; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "ready", label: "Ready" },
+  { id: "disabled", label: "Disabled" },
+  { id: "needs-setup", label: "Needs setup" },
+  { id: "incompatible", label: "Incompatible" },
+];
+
+type AgentRow = { id: string; identity?: { name?: string; emoji?: string } };
+type AgentsListResult = { defaultId?: string; agents?: AgentRow[] };
+
+type ViewMode = "installed" | "incoming";
+
 export function SkillsView() {
+  const [viewMode, setViewMode] = useState<ViewMode>("installed");
+  const [incomingCount, setIncomingCount] = useState(0);
+  const [showEditor, setShowEditor] = useState(false);
   const gwStatus = useGatewayStore((s) => s.status);
   const request = useGatewayStore((s) => s.request);
+  const subscribe = useGatewayStore((s) => s.subscribe);
+
+  const refreshIncomingCount = useCallback(async () => {
+    if (gwStatus !== "connected") return;
+    try {
+      const res = (await request("skills.incoming.list", {})) as { skills?: unknown[] };
+      setIncomingCount(Array.isArray(res?.skills) ? res.skills.length : 0);
+    } catch {
+      // non-fatal
+    }
+  }, [gwStatus, request]);
+
+  useEffect(() => {
+    refreshIncomingCount();
+  }, [refreshIncomingCount]);
+
+  useEffect(() => {
+    return subscribe((evt) => {
+      if (evt.event === "skills.changed") {
+        void refreshIncomingCount();
+      }
+    });
+  }, [subscribe, refreshIncomingCount]);
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-foreground">Skills</h1>
+        <button
+          onClick={() => setShowEditor(true)}
+          className="px-3 py-1.5 text-xs rounded-md border bg-purple-500/10 text-purple-300 border-purple-500/20 hover:bg-purple-500/20 transition-colors"
+        >
+          + New skill
+        </button>
+      </div>
+      <div className="flex items-center gap-2 border-b border-border/20 pb-2">
+        <button
+          onClick={() => setViewMode("installed")}
+          className={cn(
+            "px-3 py-1.5 text-sm rounded-md transition-colors",
+            viewMode === "installed"
+              ? "bg-purple-500/15 text-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          Installed
+        </button>
+        <button
+          onClick={() => setViewMode("incoming")}
+          className={cn(
+            "px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-1.5",
+            viewMode === "incoming"
+              ? "bg-purple-500/15 text-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          Incoming
+          {incomingCount > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-300">
+              {incomingCount}
+            </span>
+          )}
+        </button>
+      </div>
+      {viewMode === "installed" ? (
+        <InstalledSkillsView />
+      ) : (
+        <IncomingPanel onCountChange={setIncomingCount} />
+      )}
+      {showEditor && <SkillEditor onClose={() => setShowEditor(false)} />}
+    </div>
+  );
+}
+
+function InstalledSkillsView() {
+  const gwStatus = useGatewayStore((s) => s.status);
+  const request = useGatewayStore((s) => s.request);
+  const subscribe = useGatewayStore((s) => s.subscribe);
   const skills = useSkillsStore((s) => s.skills);
   const loading = useSkillsStore((s) => s.loading);
   const filter = useSkillsStore((s) => s.filter);
@@ -92,13 +357,39 @@ export function SkillsView() {
   const setFilter = useSkillsStore((s) => s.setFilter);
   const updateSkill = useSkillsStore((s) => s.updateSkill);
 
+  const [tab, setTab] = useState<FilterTab>("all");
+  const [installing, setInstalling] = useState<string | null>(null);
+  const [agents, setAgents] = useState<AgentRow[]>([]);
+  const [agentId, setAgentId] = useState<string>("");
+
+  useEffect(() => {
+    if (gwStatus !== "connected") return;
+    void (async () => {
+      try {
+        const res = (await request("agents.list", {})) as AgentsListResult;
+        const list = Array.isArray(res?.agents) ? res.agents : [];
+        setAgents(list);
+        if (!agentId && res?.defaultId) {
+          setAgentId(res.defaultId);
+        }
+      } catch {
+        // non-fatal: agent selector hides if list unavailable
+      }
+    })();
+  }, [gwStatus, request, agentId]);
+
   const refresh = useCallback(async () => {
     if (gwStatus !== "connected") return;
     setLoading(true);
     try {
-      const res = (await request("skills.status", {})) as SkillReport;
-      if (res?.skills) {
-        setSkills(res.skills);
+      const params: Record<string, unknown> = {};
+      if (agentId) params.agentId = agentId;
+      const res = (await request("skills.status", params)) as SkillReport;
+      if (Array.isArray(res?.skills)) {
+        const normalized = res.skills
+          .map(normalizeSkill)
+          .filter((s): s is SkillStatus => s !== null);
+        setSkills(normalized);
       }
       setError(null);
     } catch (err) {
@@ -106,14 +397,26 @@ export function SkillsView() {
     } finally {
       setLoading(false);
     }
-  }, [gwStatus, request, setSkills, setLoading, setError]);
+  }, [gwStatus, agentId, request, setSkills, setLoading, setError]);
 
   useEffect(() => {
     refresh();
   }, [refresh]);
 
+  useEffect(() => {
+    return subscribe((evt) => {
+      if (evt.event === "skills.changed") {
+        void refresh();
+      }
+    });
+  }, [subscribe, refresh]);
+
   const handleToggle = useCallback(
     async (key: string, enabled: boolean) => {
+      if (!key) {
+        alert("Update failed: skill is missing an identifier");
+        return;
+      }
       try {
         await request("skills.update", { skillKey: key, enabled });
         updateSkill(key, { enabled });
@@ -124,46 +427,129 @@ export function SkillsView() {
     [request, updateSkill],
   );
 
-  const filtered = filter
-    ? skills.filter(
-        (s) =>
-          s.name.toLowerCase().includes(filter.toLowerCase()) ||
-          s.key.toLowerCase().includes(filter.toLowerCase()) ||
-          s.category?.toLowerCase().includes(filter.toLowerCase()),
-      )
-    : skills;
+  const handleInstall = useCallback(
+    async (skill: SkillStatus) => {
+      const option = skill.install?.[0];
+      if (!option) return;
+      setInstalling(skill.key);
+      try {
+        await request("skills.install", { name: skill.name, installId: option.id });
+      } catch (err) {
+        alert(`Install failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      } finally {
+        setInstalling(null);
+      }
+    },
+    [request],
+  );
 
-  // Group by category
-  const groups = new Map<string, SkillStatus[]>();
-  for (const skill of filtered) {
-    const cat = skill.category ?? "Other";
-    const list = groups.get(cat) ?? [];
-    list.push(skill);
-    groups.set(cat, list);
-  }
-  const sortedGroups = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const tabCounts = useMemo(() => {
+    const counts: Record<FilterTab, number> = {
+      all: 0,
+      ready: 0,
+      disabled: 0,
+      "needs-setup": 0,
+      incompatible: 0,
+    };
+    for (const skill of skills) {
+      for (const t of TABS) {
+        if (matchesTab(skill, t.id)) counts[t.id]++;
+      }
+    }
+    return counts;
+  }, [skills]);
+
+  const filtered = useMemo(() => {
+    let list = skills.filter((s) => matchesTab(s, tab));
+    if (filter) {
+      const q = filter.toLowerCase();
+      list = list.filter(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.key.toLowerCase().includes(q) ||
+          s.category?.toLowerCase().includes(q),
+      );
+    }
+    return list;
+  }, [skills, tab, filter]);
+
+  const groups = useMemo(() => {
+    const map = new Map<string, SkillStatus[]>();
+    for (const skill of filtered) {
+      const cat = skill.category ?? "Other";
+      const list = map.get(cat) ?? [];
+      list.push(skill);
+      map.set(cat, list);
+    }
+    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [filtered]);
+
+  const readyCount = skills.filter((s) => s.state === "ready").length;
 
   return (
-    <div className="h-full overflow-y-auto p-6 space-y-4">
-      <div className="flex items-center justify-between">
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">Skills</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            {skills.filter((s) => s.enabled).length} enabled of {skills.length}
+          <p className="text-sm text-muted-foreground">
+            {readyCount} ready of {skills.length} total
           </p>
         </div>
-        <button
-          onClick={refresh}
-          disabled={loading}
-          className={cn(
-            "px-3 py-1.5 text-xs rounded-lg",
-            "bg-purple-500/10 text-purple-300 hover:bg-purple-500/20",
-            "border border-purple-500/20 transition-colors",
-            loading && "opacity-50",
+        <div className="flex items-center gap-2">
+          {agents.length > 1 && (
+            <select
+              value={agentId}
+              onChange={(e) => setAgentId(e.target.value)}
+              className={cn(
+                "h-8 px-2 text-xs rounded-lg border bg-transparent text-foreground",
+                "border-border/30 focus:border-purple-500 focus:outline-none",
+              )}
+              title="View skills for this agent"
+            >
+              {agents.map((a) => {
+                const label = a.identity?.name?.trim() || a.id;
+                return (
+                  <option key={a.id} value={a.id}>
+                    {a.identity?.emoji ? `${a.identity.emoji} ` : ""}
+                    {label}
+                  </option>
+                );
+              })}
+            </select>
           )}
-        >
-          {loading ? "Loading…" : "Refresh"}
-        </button>
+          <button
+            onClick={refresh}
+            disabled={loading}
+            className={cn(
+              "px-3 py-1.5 text-xs rounded-lg",
+              "bg-purple-500/10 text-purple-300 hover:bg-purple-500/20",
+              "border border-purple-500/20 transition-colors",
+              loading && "opacity-50",
+            )}
+          >
+            {loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-1 border-b border-border/20">
+        {TABS.map((t) => {
+          const active = t.id === tab;
+          return (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={cn(
+                "px-3 py-1.5 text-xs rounded-t-md border-b-2 transition-colors",
+                active
+                  ? "border-purple-500 text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t.label}
+              <span className="ml-1.5 text-[10px] text-muted-foreground">{tabCounts[t.id]}</span>
+            </button>
+          );
+        })}
       </div>
 
       <input
@@ -177,19 +563,25 @@ export function SkillsView() {
         )}
       />
 
-      {sortedGroups.length === 0 && !loading ? (
+      {groups.length === 0 && !loading ? (
         <div className="p-8 text-center text-muted-foreground text-sm rounded-xl border border-border/20 bg-card/60 backdrop-blur-sm">
-          No skills found
+          No skills match this view
         </div>
       ) : (
-        sortedGroups.map(([category, categorySkills]) => (
+        groups.map(([category, categorySkills]) => (
           <div key={category} className="space-y-2">
             <h3 className="text-xs font-semibold text-[#00D4E6] uppercase tracking-wider px-1">
               {category}
             </h3>
             <div className="space-y-1">
               {categorySkills.map((skill) => (
-                <SkillCard key={skill.key} skill={skill} onToggle={handleToggle} />
+                <SkillCard
+                  key={skill.key}
+                  skill={skill}
+                  onToggle={handleToggle}
+                  onInstall={handleInstall}
+                  installing={installing === skill.key}
+                />
               ))}
             </div>
           </div>

--- a/desktop/renderer/src/stores/skills-store.ts
+++ b/desktop/renderer/src/stores/skills-store.ts
@@ -1,5 +1,29 @@
 import { create } from "zustand";
 
+export type SkillState =
+  | "ready"
+  | "disabled-by-user"
+  | "missing-os"
+  | "missing-bin"
+  | "missing-env"
+  | "missing-config"
+  | "blocked-by-allowlist";
+
+export type SkillInstallOption = {
+  id: string;
+  kind: string;
+  label: string;
+  bins: string[];
+};
+
+export type SkillOrigin = {
+  registry?: string;
+  slug?: string;
+  version?: string;
+  license?: string;
+  upstreamUrl?: string;
+};
+
 export type SkillStatus = {
   key: string;
   name: string;
@@ -7,9 +31,14 @@ export type SkillStatus = {
   category?: string;
   enabled: boolean;
   installed: boolean;
-  hasApiKey?: boolean;
+  hasApiKey: boolean;
+  state: SkillState;
+  reasons: string[];
+  platformLabel?: string;
+  primaryEnv?: string;
   requires?: { bins?: string[] };
-  metadata?: Record<string, unknown>;
+  install?: SkillInstallOption[];
+  origin?: SkillOrigin;
 };
 
 type SkillsState = {

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -10,9 +10,22 @@ Bitterbot is designed to be easily extensible. "Skills" are the primary way to a
 
 A skill is a directory containing a `SKILL.md` file (which provides instructions and tool definitions to the LLM) and optionally some scripts or resources.
 
-## Step-by-Step: Your First Skill
+## Two ways to author
 
-### 1. Create the Directory
+### Option A — In-app editor (recommended)
+
+The desktop app has a built-in skill editor. Open the **Skills** view, click **+ New skill**, pick a starter template (basic / API-backed / shell-tool), edit the SKILL.md inline, and save. The editor validates frontmatter client-side and writes the file via the `skills.create` gateway method. The new skill lands disabled by default and becomes visible to the agent on its next turn (no restart required).
+
+You can target either:
+
+- **Managed** (`~/.bitterbot/skills`) — shared across every agent on this machine.
+- **Workspace** — scoped to the currently selected agent.
+
+### Option B — Filesystem (CLI / editor)
+
+If you'd rather author the skill outside the app:
+
+#### 1. Create the directory
 
 Skills live in your workspace, usually `~/.bitterbot/workspace/skills/`. Create a new folder for your skill:
 
@@ -20,7 +33,7 @@ Skills live in your workspace, usually `~/.bitterbot/workspace/skills/`. Create 
 mkdir -p ~/.bitterbot/workspace/skills/hello-world
 ```
 
-### 2. Define the `SKILL.md`
+#### 2. Define the `SKILL.md`
 
 Create a `SKILL.md` file in that directory. This file uses YAML frontmatter for metadata and Markdown for instructions.
 
@@ -35,13 +48,13 @@ description: A simple skill that says hello.
 When the user asks for a greeting, use the `echo` tool to say "Hello from your custom skill!".
 ```
 
-### 3. Add Tools (Optional)
+#### 3. Add tools (optional)
 
 You can define custom tools in the frontmatter or instruct the agent to use existing system tools (like `bash` or `browser`).
 
-### 4. Refresh Bitterbot
+#### 4. Pick it up
 
-Ask your agent to "refresh skills" or restart the gateway. Bitterbot will discover the new directory and index the `SKILL.md`.
+The skills file watcher (enabled by default) bumps the snapshot version when it sees a new `SKILL.md`. The agent picks up the change on its next turn — no manual refresh or restart needed.
 
 ## Best Practices
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -285,17 +285,54 @@ When an agent run starts, Bitterbot:
 
 This is **scoped to the agent run**, not a global shell environment.
 
-## Session snapshot (performance)
+## Session snapshot + hot reload
 
-Bitterbot snapshots the eligible skills **when a session starts** and reuses that list for subsequent turns in the same session. Changes to skills or config take effect on the next new session.
+Bitterbot snapshots eligible skills **when a session starts** and caches them for subsequent turns. The snapshot carries a `version` field that is bumped whenever the skill graph changes:
 
-Skills can also refresh mid-session when the skills watcher is enabled or when a new eligible remote node appears (see below). Think of this as a **hot reload**: the refreshed list is picked up on the next agent turn.
+- a user toggles a skill (`skills.update`)
+- a marketplace skill is accepted or rejected (`skills.incoming.accept` / `.reject`)
+- a P2P or `agentskills.io` import lands
+- a new skill is created via `skills.create` (or saved through the in-app editor)
+- the file watcher detects a `SKILL.md` add/change/unlink
+
+When the global version exceeds the cached version, the **next agent turn rebuilds the snapshot** automatically. The agent also receives a one-line diff like `[Skills change since last turn] Now available: foo. No longer available: bar.` so it can react in conversation. No session restart is needed.
+
+Cron jobs and other background runs go through the same path, so they always pick up the **fire-time** skill state, not whatever was current when the schedule was created.
+
+### `skills.changed` gateway event
+
+The gateway broadcasts `skills.changed` events to every connected client whenever the version bumps. The event payload is `{ reason, workspaceDir?, changedPath?, version }`. UI surfaces (the Skills view, Incoming queue, and any custom subscriber) refresh on this event without polling.
+
+## Two-tier prompt (agent self-awareness)
+
+The system prompt now includes two tiers of skill information:
+
+- **Tier A — eligible + enabled**: full skill metadata (name, description, location), exactly as before. The agent can invoke these directly.
+- **Tier B — soft-disabled but otherwise eligible**: skills the user has toggled off but that are installed and compatible with the current OS. The agent sees only `name: description` plus a strict policy:
+  - it MAY suggest enabling one only when it directly addresses the user's current task
+  - at most one suggestion per turn
+  - it must wait for explicit user approval before assuming the skill is available
+  - it must NOT enable skills on its own
+
+OS-incompatible skills, missing-requirement skills, and allowlist-blocked skills stay invisible to the agent (hard-disabled). This keeps the model from proposing things the user physically cannot run.
 
 ## Remote nodes (cross-platform skills)
 
 If the Gateway is running on one platform but a **remote node** on a different platform is connected **with `system.run` allowed** (Exec approvals security not set to `deny`), Bitterbot can treat platform-specific skills as eligible when the required binaries are present on that node. The agent should execute those skills via the `nodes` tool (typically `nodes.run`).
 
 This relies on the node reporting its command support and on a bin probe via `system.run`. If the remote node goes offline later, the skills remain visible; invocations may fail until the node reconnects.
+
+## Skills UI (desktop app)
+
+The desktop app's **Skills** view is the primary surface for managing skills:
+
+- **Installed tab**: every skill the agent can see, grouped by source. Each card shows a typed `state` badge (Ready / Disabled / Incompatible OS / Needs install / Needs API key / Needs config / Allowlisted off) plus reasons on hover. Filter tabs across the top scope to All / Ready / Disabled / Needs setup / Incompatible (Incompatible defaults to hidden inside the All tab).
+- **Incoming tab**: skills queued for review (P2P and agentskills.io imports). Shows author peer, signature status, injection-scan severity, content hash, and provenance. Accept moves the skill to `~/.bitterbot/skills` (still disabled until you toggle it on); Reject removes it from quarantine; Reject-all-from-peer bulk-cleans a compromised peer.
+- **Import from agentskills.io**: an inline form at the top of the Incoming tab takes a slug or full https URL and routes through the configured trust policy.
+- **Agent selector**: when more than one agent is configured, a dropdown scopes the view (and the underlying `skills.status` lookup) to that agent's workspace.
+- **+ New skill**: opens an in-app editor with three starter templates (basic / API-backed / shell-tool). Frontmatter is validated client-side. New skills land in `~/.bitterbot/skills` (or the active agent's workspace) and are immediately visible to the agent on its next turn.
+
+All UI surfaces subscribe to `skills.changed` and refresh automatically — no manual refresh required after a CLI command, P2P delivery, or another client's edit.
 
 ## Skills watcher (auto-refresh)
 

--- a/src/agents/skills-status.state-derivation.e2e.test.ts
+++ b/src/agents/skills-status.state-derivation.e2e.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildWorkspaceSkillStatus } from "./skills-status.js";
+import { writeSkill } from "./skills.e2e-test-helpers.js";
+
+// Phase 2: SkillStatusEntry now carries a single-value `state` enum plus
+// `reasons[]` and `platformLabel`. The renderer relies on this; if the
+// derivation drifts, the UI starts mis-categorizing skills.
+describe("buildWorkspaceSkillStatus state derivation", () => {
+  const incompatibleOs = process.platform === "darwin" ? "win32" : "darwin";
+
+  it("marks ready when nothing is wrong", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-state-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "ok-skill"),
+      name: "ok-skill",
+      description: "All good",
+    });
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+    });
+    const entry = report.skills.find((s) => s.skillKey === "ok-skill");
+    expect(entry?.state).toBe("ready");
+    expect(entry?.reasons).toEqual([]);
+  });
+
+  it("prefers OS mismatch over user disable (hard-disable wins)", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-state-os-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "wrong-os"),
+      name: "wrong-os",
+      description: "Won't run here",
+      metadata: `{"bitterbot": {"os": ["${incompatibleOs}"]}}`,
+    });
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      config: {
+        skills: { entries: { "wrong-os": { enabled: false } } },
+      },
+    });
+    const entry = report.skills.find((s) => s.skillKey === "wrong-os");
+    expect(entry?.state).toBe("missing-os");
+    expect(entry?.platformLabel).toBeDefined();
+  });
+
+  it("marks user-disabled when otherwise eligible", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-state-off-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "off-skill"),
+      name: "off-skill",
+      description: "Toggled off",
+    });
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      config: { skills: { entries: { "off-skill": { enabled: false } } } },
+    });
+    const entry = report.skills.find((s) => s.skillKey === "off-skill");
+    expect(entry?.state).toBe("disabled-by-user");
+  });
+
+  it("marks missing-bin when a required binary is absent", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-state-bin-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "needs-bin"),
+      name: "needs-bin",
+      description: "Wants a bin",
+      metadata: `{"bitterbot": {"requires": {"bins": ["this-binary-does-not-exist-xyzzy"]}}}`,
+    });
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+    });
+    const entry = report.skills.find((s) => s.skillKey === "needs-bin");
+    expect(entry?.state).toBe("missing-bin");
+    expect(entry?.reasons.join(" ")).toContain("this-binary-does-not-exist-xyzzy");
+  });
+});

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -27,6 +27,15 @@ export type SkillInstallOption = {
   bins: string[];
 };
 
+export type SkillState =
+  | "ready"
+  | "disabled-by-user"
+  | "missing-os"
+  | "missing-bin"
+  | "missing-env"
+  | "missing-config"
+  | "blocked-by-allowlist";
+
 export type SkillStatusEntry = {
   name: string;
   description: string;
@@ -46,6 +55,25 @@ export type SkillStatusEntry = {
   missing: Requirements;
   configChecks: SkillStatusConfigCheck[];
   install: SkillInstallOption[];
+  /**
+   * Single-value lifecycle state used by the UI. OS mismatches are hard-disabled
+   * (the user cannot un-block them by toggling); user-disabled is soft.
+   */
+  state: SkillState;
+  /** Human-readable reasons explaining the state, suitable for tooltips. */
+  reasons: string[];
+  /** Friendly platform label (e.g. "macOS only") when os is constrained. */
+  platformLabel?: string;
+  /** True when an API key is configured (via config.skills.entries[*].apiKey or env). */
+  hasApiKey: boolean;
+  /** Marketplace/upstream provenance, when this skill was imported. */
+  origin?: {
+    registry?: string;
+    slug?: string;
+    version?: string;
+    license?: string;
+    upstreamUrl?: string;
+  };
 };
 
 export type SkillStatusReport = {
@@ -166,6 +194,61 @@ function normalizeInstallOptions(
   return [toOption(preferred.spec, preferred.index)];
 }
 
+const PLATFORM_LABELS: Record<string, string> = {
+  darwin: "macOS",
+  win32: "Windows",
+  linux: "Linux",
+};
+
+function formatPlatformList(platforms: string[]): string {
+  const labelled = platforms.map((p) => PLATFORM_LABELS[p] ?? p);
+  if (labelled.length === 1) return `${labelled[0]} only`;
+  if (labelled.length === 2) return `${labelled[0]} or ${labelled[1]} only`;
+  return `${labelled.slice(0, -1).join(", ")}, or ${labelled[labelled.length - 1]} only`;
+}
+
+function deriveSkillState(params: {
+  disabled: boolean;
+  blockedByAllowlist: boolean;
+  missing: Requirements;
+}): { state: SkillState; reasons: string[] } {
+  const reasons: string[] = [];
+  const { disabled, blockedByAllowlist, missing } = params;
+  // Hard-physical incompatibilities take precedence over user toggles: a
+  // disabled-by-user toggle on a Mac-only skill running on Windows is moot;
+  // the OS mismatch is what the user actually needs to know.
+  if (missing.os.length > 0) {
+    reasons.push(`Not compatible with this OS (requires ${formatPlatformList(missing.os)}).`);
+    return { state: "missing-os", reasons };
+  }
+  if (blockedByAllowlist) {
+    reasons.push("This bundled skill is not on the allowlist.");
+    return { state: "blocked-by-allowlist", reasons };
+  }
+  if (missing.bins.length > 0 || missing.anyBins.length > 0) {
+    if (missing.bins.length > 0) {
+      reasons.push(`Missing required binaries: ${missing.bins.join(", ")}.`);
+    }
+    if (missing.anyBins.length > 0) {
+      reasons.push(`Missing at least one of: ${missing.anyBins.join(", ")}.`);
+    }
+    return { state: "missing-bin", reasons };
+  }
+  if (missing.env.length > 0) {
+    reasons.push(`Missing environment variables: ${missing.env.join(", ")}.`);
+    return { state: "missing-env", reasons };
+  }
+  if (missing.config.length > 0) {
+    reasons.push(`Missing configuration: ${missing.config.join(", ")}.`);
+    return { state: "missing-config", reasons };
+  }
+  if (disabled) {
+    reasons.push("Disabled by user.");
+    return { state: "disabled-by-user", reasons };
+  }
+  return { state: "ready", reasons };
+}
+
 function buildSkillStatus(
   entry: SkillEntry,
   config?: BitterbotConfig,
@@ -184,6 +267,12 @@ function buildSkillStatus(
       ? bundledNames.has(entry.skill.name)
       : entry.skill.source === "bitterbot-bundled";
 
+  const primaryEnv = entry.metadata?.primaryEnv;
+  const hasApiKey = Boolean(
+    skillConfig?.apiKey ||
+    (primaryEnv && (process.env[primaryEnv] || skillConfig?.env?.[primaryEnv])),
+  );
+
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryMetadataRequirements({
       always,
@@ -201,6 +290,9 @@ function buildSkillStatus(
       isConfigSatisfied: (pathStr) => isConfigPathTruthy(config, pathStr),
     });
   const eligible = !disabled && !blockedByAllowlist && requirementsSatisfied;
+  const { state, reasons } = deriveSkillState({ disabled, blockedByAllowlist, missing });
+  const declaredOs = entry.metadata?.os ?? [];
+  const platformLabel = declaredOs.length > 0 ? formatPlatformList(declaredOs) : undefined;
 
   return {
     name: entry.skill.name,
@@ -210,7 +302,7 @@ function buildSkillStatus(
     filePath: entry.skill.filePath,
     baseDir: entry.skill.baseDir,
     skillKey,
-    primaryEnv: entry.metadata?.primaryEnv,
+    primaryEnv,
     emoji,
     homepage,
     always,
@@ -221,6 +313,11 @@ function buildSkillStatus(
     missing,
     configChecks,
     install: normalizeInstallOptions(entry, prefs ?? resolveSkillsInstallPreferences(config)),
+    state,
+    reasons,
+    platformLabel,
+    hasApiKey,
+    origin: entry.metadata?.origin,
   };
 }
 

--- a/src/agents/skills.build-workspace-skills-prompt.includes-soft-disabled-tier.e2e.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.includes-soft-disabled-tier.e2e.test.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { writeSkill } from "./skills.e2e-test-helpers.js";
+import { buildWorkspaceSkillSnapshot } from "./skills.js";
+
+// Phase 4 Tier B: skills toggled off by the user but otherwise eligible
+// must surface to the agent as suggestable, with an explicit suggest policy.
+// OS-incompatible / missing-requirement skills must not leak into Tier B.
+describe("buildWorkspaceSkillSnapshot soft-disabled tier", () => {
+  it("lists user-disabled-but-eligible skills with the suggest policy", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-soft-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "ready-skill"),
+      name: "ready-skill",
+      description: "Always available",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "off-skill"),
+      name: "off-skill",
+      description: "User disabled this one",
+    });
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      config: {
+        skills: {
+          entries: {
+            "off-skill": { enabled: false },
+          },
+        },
+      },
+    });
+
+    expect(snapshot.prompt).toContain("ready-skill");
+    expect(snapshot.prompt).toContain("[Skills available but disabled by user]");
+    expect(snapshot.prompt).toContain("off-skill: User disabled this one");
+    expect(snapshot.prompt).toContain("Suggest at most one per turn");
+    // off-skill is in soft-disabled tier; it should NOT appear in the active
+    // skills array surfaced to consumers as enabled.
+    expect(snapshot.skills.some((s) => s.name === "off-skill")).toBe(false);
+    expect(snapshot.skills.some((s) => s.name === "ready-skill")).toBe(true);
+  });
+
+  it("hides OS-incompatible skills from both tiers (hard-disable)", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-os-"));
+    const incompatible = process.platform === "darwin" ? "win32" : "darwin";
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "wrong-os"),
+      name: "wrong-os",
+      description: "Should not surface",
+      metadata: `{"bitterbot": {"os": ["${incompatible}"]}}`,
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "off-skill"),
+      name: "off-skill",
+      description: "User disabled but compatible",
+    });
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      config: {
+        skills: {
+          entries: { "off-skill": { enabled: false } },
+        },
+      },
+    });
+
+    expect(snapshot.prompt).not.toContain("wrong-os");
+    expect(snapshot.prompt).toContain("off-skill");
+  });
+
+  it("emits no soft-disabled section when nothing is soft-disabled", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-empty-"));
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "ready-skill"),
+      name: "ready-skill",
+      description: "Active",
+    });
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      config: { skills: { entries: {} } },
+    });
+
+    expect(snapshot.prompt).toContain("ready-skill");
+    expect(snapshot.prompt).not.toContain("[Skills available but disabled by user]");
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -70,15 +70,22 @@ export function shouldIncludeSkill(params: {
   entry: SkillEntry;
   config?: BitterbotConfig;
   eligibility?: SkillEligibilityContext;
+  /**
+   * When true, ignore the user's `enabled: false` toggle while still applying
+   * physical/policy gates (OS, allowlist, missing requirements). Used to
+   * compute the "soft-disabled but otherwise eligible" tier surfaced to the
+   * agent as suggestable.
+   */
+  ignoreUserDisable?: boolean;
 }): boolean {
-  const { entry, config, eligibility } = params;
+  const { entry, config, eligibility, ignoreUserDisable } = params;
   const skillKey = resolveSkillKey(entry.skill, entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
   const allowBundled = normalizeAllowlist(config?.skills?.allowBundled);
   const osList = entry.metadata?.os ?? [];
   const remotePlatforms = eligibility?.remote?.platforms ?? [];
 
-  if (skillConfig?.enabled === false) {
+  if (skillConfig?.enabled === false && !ignoreUserDisable) {
     return false;
   }
   if (!isBundledSkillAllowed(entry, allowBundled)) {

--- a/src/agents/skills/ingest.ts
+++ b/src/agents/skills/ingest.ts
@@ -329,6 +329,7 @@ export async function rejectIncomingSkill(params: {
 
   try {
     await fs.rm(incomingDir, { recursive: true, force: true });
+    bumpSkillsSnapshotVersion({ reason: "manual", changedPath: incomingDir });
     log.info(`Rejected incoming skill: ${skillName}`);
     return { ok: true, action: "rejected", skillName };
   } catch (err) {
@@ -385,29 +386,79 @@ export async function rejectIncomingSkillsByPeer(params: {
   return { ok: errored.length === 0, rejected, errored };
 }
 
-export async function listIncomingSkills(config: BitterbotConfig): Promise<
-  Array<{
-    name: string;
-    author_peer_id?: string;
-    timestamp?: number;
-  }>
-> {
+export type IncomingSkillSummary = {
+  name: string;
+  author_peer_id?: string;
+  timestamp?: number;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  signatureValid?: boolean;
+  injectionScan?: { severity?: InjectionSeverity; matches?: number };
+  provenance?: Record<string, unknown>;
+  contentHash?: string;
+  expiresAt?: number;
+};
+
+function extractDescriptionFromFrontmatter(content: string): string | undefined {
+  if (!content.startsWith("---")) return undefined;
+  const end = content.indexOf("\n---", 3);
+  if (end === -1) return undefined;
+  const block = content.slice(3, end);
+  for (const rawLine of block.split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith("description:")) {
+      const value = line.slice("description:".length).trim();
+      // Strip surrounding quotes if present.
+      return value.replace(/^"|"$/g, "").replace(/^'|'$/g, "") || undefined;
+    }
+  }
+  return undefined;
+}
+
+export async function listIncomingSkills(config: BitterbotConfig): Promise<IncomingSkillSummary[]> {
   const quarantineDir =
     config.skills?.p2p?.quarantineDir ?? path.join(CONFIG_DIR, "skills-incoming");
   try {
     const entries = await fs.readdir(quarantineDir, { withFileTypes: true });
-    const skills: Array<{ name: string; author_peer_id?: string; timestamp?: number }> = [];
+    const skills: IncomingSkillSummary[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const envelopePath = path.join(quarantineDir, entry.name, ".envelope.json");
       let envelope: SkillEnvelope | undefined;
+      let envelopeMeta: Record<string, unknown> | undefined;
       try {
-        envelope = JSON.parse(await fs.readFile(envelopePath, "utf-8"));
+        const raw = await fs.readFile(envelopePath, "utf-8");
+        envelope = JSON.parse(raw);
+        envelopeMeta = envelope as unknown as Record<string, unknown>;
       } catch {}
+      let description: string | undefined;
+      if (envelope?.skill_md) {
+        try {
+          const decoded = Buffer.from(envelope.skill_md, "base64").toString("utf-8");
+          description = extractDescriptionFromFrontmatter(decoded);
+        } catch {}
+      }
+      const injectionScan = envelopeMeta?.injection_scan as
+        | { severity?: InjectionSeverity; matches?: { length?: number } | unknown[] }
+        | undefined;
+      const matchesLen = Array.isArray(injectionScan?.matches)
+        ? injectionScan.matches.length
+        : (injectionScan?.matches as { length?: number } | undefined)?.length;
       skills.push({
         name: entry.name,
         author_peer_id: envelope?.author_peer_id,
         timestamp: envelope?.timestamp,
+        description,
+        category: envelope?.category,
+        tags: envelope?.tags,
+        signatureValid: envelope ? verifySignature(envelope) : undefined,
+        injectionScan: injectionScan
+          ? { severity: injectionScan.severity, matches: matchesLen }
+          : undefined,
+        provenance: envelope?.provenance,
+        contentHash: envelope?.content_hash,
+        expiresAt: envelope?.expires_at,
       });
     }
     return skills;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -276,6 +276,44 @@ const P2P_SKILL_SECURITY_NOTICE = [
   "  wins.",
 ].join("\n");
 
+function buildSoftDisabledTier(
+  allEntries: SkillEntry[],
+  eligibleSet: Set<string>,
+  config: BitterbotConfig | undefined,
+  eligibility: SkillEligibilityContext | undefined,
+  skillFilter: string[] | undefined,
+): SkillEntry[] {
+  // A skill is "soft-disabled" iff the user toggled it off but it would
+  // otherwise be eligible (OS compatible, requirements met, allowlisted).
+  // We surface these to the agent as suggestable. Hard-disabled skills (OS
+  // mismatch, missing bins, etc.) stay hidden so the model cannot propose
+  // enabling something the user physically cannot run.
+  const filterSet = skillFilter && skillFilter.length > 0 ? new Set(skillFilter) : undefined;
+  return allEntries.filter((entry) => {
+    if (eligibleSet.has(entry.skill.name)) return false;
+    if (filterSet && !filterSet.has(entry.skill.name)) return false;
+    if (entry.invocation?.disableModelInvocation === true) return false;
+    return shouldIncludeSkill({ entry, config, eligibility, ignoreUserDisable: true });
+  });
+}
+
+function formatSoftDisabledTier(entries: SkillEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = [
+    "[Skills available but disabled by user]",
+    "Rules for these skills:",
+    "- They exist on disk and are compatible with the user's system, but the user has toggled them off.",
+    "- You MAY suggest enabling one only when it directly addresses what the user just asked for.",
+    "- Suggest at most one per turn. Name the user's task and explain why this skill specifically fits.",
+    "- Wait for explicit user approval before assuming the skill is available; do not enable any of them yourself.",
+  ];
+  for (const entry of entries.toSorted((a, b) => a.skill.name.localeCompare(b.skill.name))) {
+    const desc = entry.skill.description?.trim();
+    lines.push(`- ${entry.skill.name}${desc ? `: ${desc}` : ""}`);
+  }
+  return lines.join("\n");
+}
+
 export function buildWorkspaceSkillSnapshot(
   workspaceDir: string,
   opts?: {
@@ -306,7 +344,21 @@ export function buildWorkspaceSkillSnapshot(
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const anyP2POrigin = resolvedSkills.some((s) => hasP2PProvenance(s));
   const securityNotice = anyP2POrigin ? P2P_SKILL_SECURITY_NOTICE : "";
-  const prompt = [remoteNote, securityNotice, formatSkillsForPrompt(resolvedSkills)]
+  const eligibleNames = new Set(eligible.map((e) => e.skill.name));
+  const softDisabled = buildSoftDisabledTier(
+    skillEntries,
+    eligibleNames,
+    opts?.config,
+    opts?.eligibility,
+    opts?.skillFilter,
+  );
+  const softDisabledNote = formatSoftDisabledTier(softDisabled);
+  const prompt = [
+    remoteNote,
+    securityNotice,
+    formatSkillsForPrompt(resolvedSkills),
+    softDisabledNote,
+  ]
     .filter(Boolean)
     .join("\n\n");
   const skillFilter = normalizeSkillFilter(opts?.skillFilter);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -84,6 +84,27 @@ function resolveFallbackRetryPrompt(params: { body: string; isFallbackRetry: boo
   return "Continue where you left off. The previous model attempt failed or timed out.";
 }
 
+function formatSkillsChangeNote(
+  previous: { skills?: Array<{ name: string }> } | undefined,
+  next: { skills?: Array<{ name: string }> } | undefined,
+): string {
+  const prevNames = new Set((previous?.skills ?? []).map((s) => s.name));
+  const nextNames = new Set((next?.skills ?? []).map((s) => s.name));
+  const added: string[] = [];
+  for (const name of nextNames) {
+    if (!prevNames.has(name)) added.push(name);
+  }
+  const removed: string[] = [];
+  for (const name of prevNames) {
+    if (!nextNames.has(name)) removed.push(name);
+  }
+  if (added.length === 0 && removed.length === 0) return "";
+  const lines = ["[Skills change since last turn]"];
+  if (added.length > 0) lines.push(`Now available: ${added.toSorted().join(", ")}.`);
+  if (removed.length > 0) lines.push(`No longer available: ${removed.toSorted().join(", ")}.`);
+  return lines.join("\n");
+}
+
 function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
@@ -312,9 +333,12 @@ export async function agentCommand(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const cachedSnapshotVersion = sessionEntry?.skillsSnapshot?.version ?? -1;
+    const snapshotIsStale = cachedSnapshotVersion < skillsSnapshotVersion;
+    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot || snapshotIsStale;
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const previousSnapshot = sessionEntry?.skillsSnapshot;
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,
@@ -323,6 +347,17 @@ export async function agentCommand(
           skillFilter,
         })
       : sessionEntry?.skillsSnapshot;
+
+    // Hot-toggle awareness: if we rebuilt mid-session because the user (or
+    // marketplace) changed skills, surface the diff to the agent so its next
+    // turn can reflect "X is now available" / "Y was disabled" without the
+    // user needing to retell it.
+    if (needsSkillsSnapshot && !isNewSession && previousSnapshot && skillsSnapshot) {
+      const note = formatSkillsChangeNote(previousSnapshot, skillsSnapshot);
+      if (note) {
+        skillsSnapshot.prompt = `${note}\n\n${skillsSnapshot.prompt}`.trim();
+      }
+    }
 
     if (skillsSnapshot && sessionStore && sessionKey && needsSkillsSnapshot) {
       const current = sessionEntry ?? {

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -167,6 +167,8 @@ import {
   type SkillsBinsParams,
   SkillsBinsParamsSchema,
   type SkillsBinsResult,
+  type SkillsCreateParams,
+  SkillsCreateParamsSchema,
   type SkillsInstallParams,
   SkillsInstallParamsSchema,
   type SkillsStatusParams,
@@ -300,6 +302,7 @@ export const validateSkillsBinsParams = ajv.compile<SkillsBinsParams>(SkillsBins
 export const validateSkillsInstallParams =
   ajv.compile<SkillsInstallParams>(SkillsInstallParamsSchema);
 export const validateSkillsUpdateParams = ajv.compile<SkillsUpdateParams>(SkillsUpdateParamsSchema);
+export const validateSkillsCreateParams = ajv.compile<SkillsCreateParams>(SkillsCreateParamsSchema);
 export const validateDevicePairListParams = ajv.compile<DevicePairListParams>(
   DevicePairListParamsSchema,
 );
@@ -454,6 +457,7 @@ export {
   SkillsStatusParamsSchema,
   SkillsInstallParamsSchema,
   SkillsUpdateParamsSchema,
+  SkillsCreateParamsSchema,
   LogsTailParamsSchema,
   LogsTailResultSchema,
   ChatHistoryParamsSchema,
@@ -536,6 +540,7 @@ export type {
   SkillsBinsResult,
   SkillsInstallParams,
   SkillsUpdateParams,
+  SkillsCreateParams,
   NodePairRejectParams,
   NodePairVerifyParams,
   NodeListParams,

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -207,3 +207,17 @@ export const SkillsUpdateParamsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+export const SkillsCreateParamsSchema = Type.Object(
+  {
+    name: NonEmptyString,
+    content: NonEmptyString,
+    /** Where to write the skill: "managed" (~/.bitterbot/skills) or "workspace". */
+    target: Type.Optional(Type.Union([Type.Literal("managed"), Type.Literal("workspace")])),
+    /** Optional agent ID; only used when target = "workspace". */
+    agentId: Type.Optional(NonEmptyString),
+    /** Refuse to overwrite an existing skill at the same path. */
+    overwrite: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -29,6 +29,7 @@ import type {
   ModelsListResultSchema,
   SkillsBinsParamsSchema,
   SkillsBinsResultSchema,
+  SkillsCreateParamsSchema,
   SkillsInstallParamsSchema,
   SkillsStatusParamsSchema,
   SkillsUpdateParamsSchema,
@@ -202,6 +203,7 @@ export type SkillsBinsParams = Static<typeof SkillsBinsParamsSchema>;
 export type SkillsBinsResult = Static<typeof SkillsBinsResultSchema>;
 export type SkillsInstallParams = Static<typeof SkillsInstallParamsSchema>;
 export type SkillsUpdateParams = Static<typeof SkillsUpdateParamsSchema>;
+export type SkillsCreateParams = Static<typeof SkillsCreateParamsSchema>;
 export type LogsTailParams = Static<typeof LogsTailParamsSchema>;
 export type LogsTailResult = Static<typeof LogsTailResultSchema>;
 export type ExecApprovalsGetParams = Static<typeof ExecApprovalsGetParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -47,6 +47,7 @@ const BASE_METHODS = [
   "skills.network",
   "skills.networkHistory",
   "skills.update",
+  "skills.create",
   "skills.incoming.list",
   "skills.incoming.accept",
   "skills.incoming.reject",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -207,6 +207,7 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
     method === "agents.delete" ||
     method === "skills.install" ||
     method === "skills.update" ||
+    method === "skills.create" ||
     method === "sessions.patch" ||
     method === "sessions.reset" ||
     method === "sessions.delete" ||

--- a/src/gateway/server-methods/skills.create.test.ts
+++ b/src/gateway/server-methods/skills.create.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+vi.mock("../../utils.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../utils.js")>();
+  return {
+    ...original,
+    get CONFIG_DIR() {
+      return tmpDir;
+    },
+  };
+});
+
+vi.mock("../../config/config.js", () => {
+  return {
+    loadConfig: () => ({}),
+    writeConfigFile: async () => {},
+  };
+});
+
+const { skillsHandlers } = await import("./skills.js");
+
+const VALID_CONTENT = `---
+name: hello
+description: A test skill
+---
+
+# Hello
+
+Body.
+`;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "skills-create-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("skills.create", () => {
+  it("writes a managed SKILL.md and reports success", async () => {
+    let ok: boolean | null = null;
+    let result: { skillName?: string; skillPath?: string; target?: string } | null = null;
+    await skillsHandlers["skills.create"]({
+      params: { name: "Hello World", content: VALID_CONTENT },
+      respond: (success, payload) => {
+        ok = success;
+        result = payload as typeof result;
+      },
+    });
+    expect(ok).toBe(true);
+    expect(result?.skillName).toBe("hello-world");
+    expect(result?.target).toBe("managed");
+    const onDisk = await fs.readFile(
+      path.join(tmpDir, "skills", "hello-world", "SKILL.md"),
+      "utf-8",
+    );
+    expect(onDisk).toBe(VALID_CONTENT);
+  });
+
+  it("rejects content that is not valid YAML frontmatter", async () => {
+    let ok: boolean | null = null;
+    let error: { message?: string } | undefined;
+    await skillsHandlers["skills.create"]({
+      params: { name: "broken", content: "no frontmatter here" },
+      respond: (success, _payload, err) => {
+        ok = success;
+        error = err;
+      },
+    });
+    expect(ok).toBe(false);
+    expect(error?.message).toMatch(/frontmatter/i);
+  });
+
+  it("refuses to overwrite an existing skill unless overwrite=true", async () => {
+    await skillsHandlers["skills.create"]({
+      params: { name: "dup", content: VALID_CONTENT },
+      respond: () => {},
+    });
+
+    let ok: boolean | null = null;
+    let error: { message?: string } | undefined;
+    await skillsHandlers["skills.create"]({
+      params: { name: "dup", content: VALID_CONTENT },
+      respond: (success, _payload, err) => {
+        ok = success;
+        error = err;
+      },
+    });
+    expect(ok).toBe(false);
+    expect(error?.message).toMatch(/already exists/);
+
+    let ok2: boolean | null = null;
+    await skillsHandlers["skills.create"]({
+      params: { name: "dup", content: VALID_CONTENT, overwrite: true },
+      respond: (success) => {
+        ok2 = success;
+      },
+    });
+    expect(ok2).toBe(true);
+  });
+
+  it("rejects names that normalize to empty", async () => {
+    let ok: boolean | null = null;
+    await skillsHandlers["skills.create"]({
+      params: { name: "!!!", content: VALID_CONTENT },
+      respond: (success) => {
+        ok = success;
+      },
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { CrystallizationCandidate } from "../../agents/skills/types.js";
 import type { BitterbotConfig } from "../../config/config.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -17,16 +19,19 @@ import {
   rejectIncomingSkill,
   rejectIncomingSkillsByPeer,
 } from "../../agents/skills/ingest.js";
+import { bumpSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { CONFIG_DIR } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
   validateSkillsBinsParams,
+  validateSkillsCreateParams,
   validateSkillsInstallParams,
   validateSkillsStatusParams,
   validateSkillsUpdateParams,
@@ -295,7 +300,86 @@ export const skillsHandlers: GatewayRequestHandlers = {
       skills,
     };
     await writeConfigFile(nextConfig);
+    bumpSkillsSnapshotVersion({ reason: "manual" });
     respond(true, { ok: true, skillKey: p.skillKey, config: current }, undefined);
+  },
+  "skills.create": async ({ params, respond }) => {
+    if (!validateSkillsCreateParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid skills.create params: ${formatValidationErrors(validateSkillsCreateParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as {
+      name: string;
+      content: string;
+      target?: "managed" | "workspace";
+      agentId?: string;
+      overwrite?: boolean;
+    };
+    const sanitizedName = p.name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 64);
+    if (!sanitizedName) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "name normalizes to empty after sanitization"),
+      );
+      return;
+    }
+    if (!p.content.startsWith("---")) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "SKILL.md must start with YAML frontmatter (---)"),
+      );
+      return;
+    }
+    const cfg = loadConfig();
+    const target = p.target ?? "managed";
+    let baseDir: string;
+    if (target === "workspace") {
+      const agentId = p.agentId ? normalizeAgentId(p.agentId) : resolveDefaultAgentId(cfg);
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+      baseDir = path.join(workspaceDir, "skills");
+    } else {
+      baseDir = path.join(CONFIG_DIR, "skills");
+    }
+    const skillDir = path.join(baseDir, sanitizedName);
+    const skillPath = path.join(skillDir, "SKILL.md");
+    if (!p.overwrite) {
+      try {
+        await fs.access(skillPath);
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `skill "${sanitizedName}" already exists at ${skillPath}; pass overwrite=true to replace`,
+          ),
+        );
+        return;
+      } catch {
+        // expected: file doesn't exist
+      }
+    }
+    try {
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(skillPath, p.content, "utf-8");
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, `write failed: ${String(err)}`));
+      return;
+    }
+    bumpSkillsSnapshotVersion({ reason: "manual", changedPath: skillPath });
+    respond(true, { ok: true, skillName: sanitizedName, skillPath, target }, undefined);
   },
   "skills.incoming.list": async ({ respond }) => {
     const cfg = loadConfig();

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -5,7 +5,10 @@ import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
-import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
+import {
+  getSkillsSnapshotVersion,
+  registerSkillsChangeListener,
+} from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
@@ -380,6 +383,16 @@ export async function startGatewayServer(
   const skillsChangeUnsub = minimalTestGateway
     ? () => {}
     : registerSkillsChangeListener((event) => {
+        broadcast(
+          "skills.changed",
+          {
+            reason: event.reason,
+            workspaceDir: event.workspaceDir,
+            changedPath: event.changedPath,
+            version: getSkillsSnapshotVersion(event.workspaceDir),
+          },
+          { dropIfSlow: true },
+        );
         if (event.reason === "remote-node") {
           return;
         }


### PR DESCRIPTION
## Summary

Phase 1-5 of the skills system overhaul. Toggling, marketplace ingestion, and skill creation now propagate to the running agent without a session restart; the desktop UI surfaces every state-machine decision the server makes; and the agent gains awareness of disabled-but-eligible skills with a strict suggest policy.

- **Phase 1 — reactive snapshots.** Snapshot version invalidates on bump, agent rebuilds on next turn, gateway broadcasts `skills.changed`, renderer auto-refreshes. Every mutation site (toggle / accept / reject / file watcher / P2P / agentskills.io / new skill) participates.
- **Phase 2 — typed status contract.** Server returns a single-value `state` enum plus `reasons[]`, `platformLabel`, `hasApiKey`, `origin`. Renderer rebuilt around it: state badges, filter tabs (All / Ready / Disabled / Needs setup / Incompatible), install-dependency button, agent selector.
- **Phase 3 — marketplace UI.** New `IncomingPanel` with provenance, signature status, injection-scan severity, accept/reject/rejectByPeer. Inline `Import from agentskills.io` (slug or URL). Per-skill provenance row with upstream link.
- **Phase 4 — agent self-awareness.** Two-tier prompt: Tier A active skills, Tier B soft-disabled-but-eligible with a strict suggest policy (1/turn, named user task, awaits approval). OS-incompatible / missing-requirement skills stay invisible (hard-disable). `shouldIncludeSkill` got an `ignoreUserDisable` flag.
- **Phase 5 — in-app skill creation.** New `skills.create` gateway method (managed or workspace target, frontmatter validation, overwrite refusal). React `SkillEditor` modal with three starter templates (basic / API-backed / shell-tool). New skills auto-trigger `skills.changed` so the agent sees them next turn.

Cron jobs already use fire-time skill state through the universal `runAgent` path (Phase 1 invalidation covers them). Verified, no code change needed.

## Tests

- 11 new tests added (4 unit for `skills.create`; 3 e2e for Tier B prompt; 4 e2e for state derivation).
- 86 pre-existing skill unit tests still pass.
- 9 pre-existing prompt-building e2e tests still pass.
- Typecheck clean across monorepo. Lint clean (pre-commit hook).

## Docs

- `docs/tools/skills.md`: replaced the stale "snapshot at session start" section with hot-reload semantics and the `skills.changed` event contract; added Two-tier prompt and Skills UI sections.
- `docs/tools/creating-skills.md`: added in-app editor flow ahead of the filesystem flow.

## Deferred follow-ups (documented in commit body and project memory)

- Trust controls UI (Settings sub-page wiring `config.get` / `config.patch` for `skills.p2p.maxIngestedPerHour`, `agentskills.defaultTrust`, allowlist).
- Per-agent allowlist mutation (`skills.updateAgentFilter` server method).
- Per-skill use telemetry feeding the reputation system.
- Editor v2 (Monaco, sandbox runner, sign+gossip publish, agentskills.io upload, draft persistence).
- Phase 6 Tool Search pattern (only when installed-skills exceeds ~50).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/agents/skills src/gateway/server-methods/skills` — 86 + 4 new = 90 unit tests pass
- [x] `pnpm vitest run --config vitest.e2e.config.ts "skills"` — 9 + 7 new = 16 e2e tests pass
- [x] Pre-commit lint hook clean
- [ ] Smoke test: toggle a skill in the desktop UI; verify agent picks up the change on next turn (one-line `[Skills change since last turn]` note)
- [ ] Smoke test: import a skill from agentskills.io via the new inline form; verify it lands in the Incoming queue
- [ ] Smoke test: create a skill via the editor modal; verify it appears immediately in Installed (disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)