### PR TITLE
ci: add Tessl skill review workflow (SHA-pinned)

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead  # pin to SHA for supply-chain safety
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,4 +1,4 @@
-# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Tessl Skill Review — runs on PRs that change any SKILL.md
 # Docs: https://github.com/tesslio/skill-review
 name: Tessl Skill Review
 
@@ -16,7 +16,4 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead  # pin to SHA for supply-chain safety
-      # Optional quality gate (off by default — do not enable unless user asked):
-      # with:
-      #   fail-threshold: 70
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead


### PR DESCRIPTION
Hey @VGIL77 👋

Following up on the feedback from #13 — this is a standalone PR with just the Tessl Skill Review workflow, pinned to a specific SHA as requested.

### What's included

`.github/workflows/skill-review.yml` — runs `tessl skill review` on PRs that touch `SKILL.md` files and posts scores as a PR comment.

**Pinned to SHA:** `tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead` (not `@main`)

### What this gives you

- 🔍 Automatic `tessl skill review` on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and feedback
- 🔓 No extra accounts — only `GITHUB_TOKEN` is used
- ✅ Non-blocking by default — feedback-only, no red CI
- 🔒 SHA-pinned for supply-chain safety

No skill changes bundled — just the workflow.

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just addressing the specific ask from last time.

Thanks in advance 🙏