### PR TITLE
fix(access-control): normalize inbound candidates before allowlist comparison

### DIFF
--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -55,7 +55,8 @@ export async function checkInboundAccessControl(params: {
   const groupAllowFrom =
     account.groupAllowFrom ??
     (configuredAllowFrom && configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
-  const isSamePhone = params.from === params.selfE164;
+  const isSamePhone =
+    normalizeE164(params.from) === normalizeE164(params.selfE164 ?? "");
   const isSelfChat = isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0
@@ -103,9 +104,12 @@ export async function checkInboundAccessControl(params: {
         resolvedAccountId: account.accountId,
       };
     }
+    const normalizedSenderE164 =
+      params.senderE164 != null ? normalizeE164(params.senderE164) : null;
     const senderAllowed =
       groupHasWildcard ||
-      (params.senderE164 != null && normalizedGroupAllowFrom.includes(params.senderE164));
+      (normalizedSenderE164 != null &&
+        normalizedGroupAllowFrom.includes(normalizedSenderE164));
     if (!senderAllowed) {
       logVerbose(
         `Blocked group message from ${params.senderE164 ?? "unknown sender"} (groupPolicy: allowlist)`,
@@ -140,7 +144,7 @@ export async function checkInboundAccessControl(params: {
       };
     }
     if (dmPolicy !== "open" && !isSamePhone) {
-      const candidate = params.from;
+      const candidate = normalizeE164(params.from);
       const allowed =
         dmHasWildcard ||
         (normalizedAllowFrom.length > 0 && normalizedAllowFrom.includes(candidate));


### PR DESCRIPTION
## Problem

`checkInboundAccessControl` normalizes the allowlist entries via `normalizeE164` but compares them against raw `params.from` and `params.senderE164`. A sender stored as `"14155551234"` in the allowlist silently rejects an inbound message from `"+1 415-555-1234"`. The `isSamePhone` self-chat check has the same issue (raw string equality).

Found by AntFleet two-model consensus review (Claude Opus 4.7 + GPT-5 unanimous, HIGH severity):
https://github.com/AntFleet/bench-bitterbot-desktop/pull/3#issuecomment-4562428247

## Fix

Normalize `params.from` and `params.senderE164` before the `includes()` and equality checks:

```ts
// DM candidate
const candidate = normalizeE164(params.from);

// Group sender
const normalizedSenderE164 = params.senderE164 != null ? normalizeE164(params.senderE164) : null;

// Self-chat check
const isSamePhone = normalizeE164(params.from) === normalizeE164(params.selfE164 ?? "");
```

## Test

Add cases where `allowFrom` contains normalized numbers (e.g. `"14155551234"`) while `params.from` is `"+1 415-555-1234"` — expect `allowed: true`. Same for group `senderE164` with `"+"` prefix.