### PR TITLE
test(access-control): regression coverage for #37 inbound candidate normalization

### DIFF
--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -129,3 +129,94 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });
+
+describe("inbound candidate normalization (#37)", () => {
+  it("allows a DM when allowFrom is stored without '+' and from is raw formatted", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          accounts: {
+            work: {
+              allowFrom: ["14155551234"],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "work",
+      from: "+1 415-555-1234",
+      selfE164: "+15550009999",
+      senderE164: "+1 415-555-1234",
+      group: false,
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "14155551234@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a group message when groupAllowFrom is stored without '+' and senderE164 has formatting", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          accounts: {
+            work: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["14155551234"],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "work",
+      from: "group-jid@g.us",
+      selfE164: "+15550009999",
+      senderE164: "+1 415-555-1234",
+      group: true,
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "group-jid@g.us",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("treats self-chat as same phone even when from and selfE164 differ in formatting", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          accounts: {
+            work: {
+              dmPolicy: "allowlist",
+              allowFrom: ["+15559999999"],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "work",
+      from: "14155559999",
+      selfE164: "+1 415-555-9999",
+      senderE164: "14155559999",
+      group: false,
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "14155559999@s.whatsapp.net",
+    });
+
+    // isSamePhone short-circuits the allowlist check, so this is allowed
+    // even though "14155559999" is not in allowFrom.
+    expect(result.allowed).toBe(true);
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -55,8 +55,7 @@ export async function checkInboundAccessControl(params: {
   const groupAllowFrom =
     account.groupAllowFrom ??
     (configuredAllowFrom && configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
-  const isSamePhone =
-    normalizeE164(params.from) === normalizeE164(params.selfE164 ?? "");
+  const isSamePhone = normalizeE164(params.from) === normalizeE164(params.selfE164 ?? "");
   const isSelfChat = isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0
@@ -108,8 +107,7 @@ export async function checkInboundAccessControl(params: {
       params.senderE164 != null ? normalizeE164(params.senderE164) : null;
     const senderAllowed =
       groupHasWildcard ||
-      (normalizedSenderE164 != null &&
-        normalizedGroupAllowFrom.includes(normalizedSenderE164));
+      (normalizedSenderE164 != null && normalizedGroupAllowFrom.includes(normalizedSenderE164));
     if (!senderAllowed) {
       logVerbose(
         `Blocked group message from ${params.senderE164 ?? "unknown sender"} (groupPolicy: allowlist)`,


### PR DESCRIPTION
## Summary
Follow-up to #37. Two things:

1. Adds the regression tests called out in the #37 PR description but not included in the merge, so the inbound-candidate normalization fix is locked in.
2. Re-collapses two lines in `src/web/inbound/access-control.ts` that `oxfmt --check` flagged on the post-merge `main` (the lint failure was inherited from #37).

### Regression tests
Three new cases in `src/web/inbound/access-control.test.ts`:
- DM allowed when `allowFrom` is stored without `+` (e.g. `"14155551234"`) and `params.from` arrives with formatting (`"+1 415-555-1234"`).
- Group sender allowed when `groupAllowFrom` is stored without `+` and `params.senderE164` arrives with formatting.
- `isSamePhone` self-chat short-circuit still fires when `params.from` and `params.selfE164` differ in formatting.

All three would have failed against the pre-#37 code path; all three pass on top of `main` post-merge.

## Test plan
- [x] `pnpm exec vitest run src/web/inbound/access-control.test.ts` -> 7/7 pass
- [x] `pnpm exec oxfmt --check src/web/inbound/access-control.ts` -> clean