### PR TITLE
fix(x402): bind declared amount to on-chain Transfer log value and USDC contract (closes #38)

### DIFF
--- a/src/services/x402-verify.test.ts
+++ b/src/services/x402-verify.test.ts
@@ -35,7 +35,7 @@ let mockedReceiptStore: Record<
   {
     status: "success" | "reverted";
     to: string;
-    logs: { topics: string[]; data: string }[];
+    logs: { address?: string; topics: string[]; data: string }[];
   }
 > = {};
 function mockedReceipt(hash: string) {
@@ -57,6 +57,14 @@ function encodeToken(payload: Record<string, unknown>): string {
   return Buffer.from(JSON.stringify(payload)).toString("base64");
 }
 
+// Encode a USDC amount (human, e.g. 0.05) as a 32-byte big-endian hex string
+// in 6-decimal base units, matching the non-indexed `value` field of an
+// ERC-20 Transfer event.
+function encodeTransferValue(humanAmount: number): string {
+  const baseUnits = BigInt(Math.round(humanAmount * 1_000_000));
+  return "0x" + baseUnits.toString(16).padStart(64, "0");
+}
+
 describe("verifyX402Payment", () => {
   const recipient = "0x" + "11".repeat(20);
   const sender = "0x" + "22".repeat(20);
@@ -68,6 +76,8 @@ describe("verifyX402Payment", () => {
       status?: "success" | "reverted";
       to?: string;
       transferTo?: string;
+      tokenAddress?: string;
+      transferValue?: number; // human USDC amount, defaults to 1 USDC (covers all test minimums)
     },
   ) {
     mockedReceiptStore[hash.toLowerCase()] = {
@@ -75,12 +85,13 @@ describe("verifyX402Payment", () => {
       to: opts?.to ?? usdcContract,
       logs: [
         {
+          address: opts?.tokenAddress ?? usdcContract,
           topics: [
             TRANSFER_TOPIC,
             topicForAddress(sender),
             topicForAddress(opts?.transferTo ?? recipient),
           ],
-          data: "0x0",
+          data: encodeTransferValue(opts?.transferValue ?? 1),
         },
       ],
     };
@@ -135,7 +146,7 @@ describe("verifyX402Payment", () => {
       network: "base",
     });
     expect(r.valid).toBe(false);
-    expect(r.error).toMatch(/recipient does not match/);
+    expect(r.error).toMatch(/No USDC Transfer log to expected recipient/);
   });
 
   it("accepts valid unsigned legacy token (with deprecation warning)", async () => {
@@ -214,6 +225,79 @@ describe("verifyX402Payment", () => {
     });
     expect(r.valid).toBe(false);
     expect(r.error).toMatch(/recipient does not match expected/);
+  });
+
+  it("rejects when on-chain Transfer value is below declared amount (#38 inflation)", async () => {
+    // Declares 1.00 USDC but the on-chain Transfer only moved 0.0001 USDC.
+    // Pre-fix this would have passed and recorded amountUsdc: 1.00 in marketplace
+    // accounting, inflating revenue shares.
+    setReceipt("0xinflate", { transferValue: 0.0001 });
+    const r = await verifyX402Payment({
+      paymentToken: encodeToken({
+        txHash: "0xinflate",
+        amount: 1.0,
+        sender,
+        timestamp: Date.now(),
+      }),
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+    });
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/below declared amount/);
+  });
+
+  it("accepts when on-chain Transfer value equals declared amount", async () => {
+    setReceipt("0xexact", { transferValue: 0.05 });
+    const r = await verifyX402Payment({
+      paymentToken: encodeToken({
+        txHash: "0xexact",
+        amount: 0.05,
+        sender,
+        timestamp: Date.now(),
+      }),
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+    });
+    expect(r.valid).toBe(true);
+  });
+
+  it("accepts when on-chain Transfer value exceeds declared amount (overpayment)", async () => {
+    setReceipt("0xover", { transferValue: 0.5 });
+    const r = await verifyX402Payment({
+      paymentToken: encodeToken({
+        txHash: "0xover",
+        amount: 0.05,
+        sender,
+        timestamp: Date.now(),
+      }),
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+    });
+    expect(r.valid).toBe(true);
+  });
+
+  it("rejects Transfer log emitted by a non-USDC contract (#38 fake-token)", async () => {
+    // Real Transfer to recipient with the right value, but emitted by an
+    // attacker-deployed contract instead of USDC. Pre-fix this would have
+    // passed because only the topic+recipient were checked.
+    const fakeToken = "0x" + "ff".repeat(20);
+    setReceipt("0xfake", { tokenAddress: fakeToken, transferValue: 1.0 });
+    const r = await verifyX402Payment({
+      paymentToken: encodeToken({
+        txHash: "0xfake",
+        amount: 0.05,
+        sender,
+        timestamp: Date.now(),
+      }),
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+    });
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/No USDC Transfer log/);
   });
 
   it("rejects a token whose tx_hash has already been consumed (replay)", async () => {

--- a/src/services/x402-verify.ts
+++ b/src/services/x402-verify.ts
@@ -10,7 +10,11 @@
  * 2. The transaction exists on-chain
  * 3. The recipient matches our wallet address (exact match against Transfer
  *    event log, not the substring check it used to do)
- * 4. The amount meets the minimum requirement
+ * 4. The Transfer log is emitted by the canonical USDC contract for the chain,
+ *    and its value is >= the declared amount (binds the token's declared amount
+ *    to the actual on-chain transfer; otherwise a real $0.0001 transfer can be
+ *    declared as $1000 and inflate accounting). The declared amount must also
+ *    be >= the configured minimum.
  * 5. The transaction is recent (within 5 minutes to prevent replay)
  * 6. The transaction hasn't already been consumed (UNIQUE on tx_hash)
  *
@@ -23,6 +27,22 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { canonicalizePaymentPayload } from "./a2a-client.js";
 
 const log = createSubsystemLogger("x402-verify");
+
+// Canonical USDC contract addresses on Base. Pinning these here lets us reject
+// Transfer events emitted by attacker-deployed fake tokens — without this, a
+// recipient-matching Transfer from any contract would pass verification.
+const USDC_CONTRACT: Record<"base" | "base-sepolia", string> = {
+  base: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "base-sepolia": "0x036cbd53842c5426634e7929541ec2318f3dcf7e",
+};
+const USDC_DECIMALS = 6;
+
+function declaredAmountToBaseUnits(amount: number): bigint {
+  // amount is human USDC (e.g. 0.05). Multiply to 6-decimal base units with
+  // rounding so floating-point representation of "0.05" doesn't truncate to
+  // 49999 base units.
+  return BigInt(Math.round(amount * 10 ** USDC_DECIMALS));
+}
 
 export interface X402VerificationResult {
   valid: boolean;
@@ -146,26 +166,47 @@ export async function verifyX402Payment(params: {
         return { valid: false, error: "Transaction failed on-chain" };
       }
 
-      // Verify recipient matches our wallet address (case-insensitive).
-      // For ERC-20 (USDC), receipt.to is the token contract, not the recipient,
-      // so we decode Transfer event logs instead.
+      // Require a USDC Transfer log to our recipient with value >= declared
+      // amount. Three independent checks bound together:
+      //   (a) `log.address` is the canonical USDC contract for this chain —
+      //       blocks fake-token Transfer events emitted by attacker contracts.
+      //   (b) `topics[2]` (indexed `to`) equals expectedRecipient, exact match
+      //       on the last 20 bytes — blocks the substring false-positive that
+      //       a prior version had.
+      //   (c) `log.data` (non-indexed `value`) >= declared amount in base units
+      //       — blocks the "real $0.0001 transfer, declared $1000" inflation
+      //       (#38). Declared amount has already been checked vs minimumAmount.
+      const transferTopic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
       const expectedRecipient = params.expectedRecipient.toLowerCase();
-      if (receipt.to?.toLowerCase() !== expectedRecipient) {
-        const transferTopic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
-        // ERC-20 Transfer indexed `to` is in topics[2] as a 32-byte left-padded
-        // hex string. Slice the last 20 bytes (40 hex chars) for exact equality
-        // — the previous .includes() check could false-positive against any
-        // address that happened to contain the recipient's hex as a substring.
-        const transferLog = receipt.logs.find((l) => {
-          if (l.topics[0] !== transferTopic) return false;
-          const topic2 = l.topics[2];
-          if (!topic2 || topic2.length < 26) return false;
-          const recipientFromLog = ("0x" + topic2.slice(26)).toLowerCase();
-          return recipientFromLog === expectedRecipient;
-        });
-        if (!transferLog) {
-          return { valid: false, error: "Transaction recipient does not match" };
-        }
+      const expectedToken = USDC_CONTRACT[params.network ?? "base-sepolia"];
+      const declaredBaseUnits = declaredAmountToBaseUnits(amount);
+
+      const transferLog = receipt.logs.find((l) => {
+        if (l.address?.toLowerCase() !== expectedToken) return false;
+        if (l.topics[0] !== transferTopic) return false;
+        const topic2 = l.topics[2];
+        if (!topic2 || topic2.length < 26) return false;
+        const recipientFromLog = ("0x" + topic2.slice(26)).toLowerCase();
+        return recipientFromLog === expectedRecipient;
+      });
+      if (!transferLog) {
+        return {
+          valid: false,
+          error: "No USDC Transfer log to expected recipient in transaction",
+        };
+      }
+
+      let onChainBaseUnits: bigint;
+      try {
+        onChainBaseUnits = BigInt(transferLog.data);
+      } catch {
+        return { valid: false, error: "Malformed Transfer log value" };
+      }
+      if (onChainBaseUnits < declaredBaseUnits) {
+        return {
+          valid: false,
+          error: `On-chain Transfer value ${onChainBaseUnits} below declared amount ${declaredBaseUnits} (USDC base units)`,
+        };
       }
     } catch (err) {
       return { valid: false, error: `On-chain verification failed: ${String(err)}` };


### PR DESCRIPTION
Closes #38.

## Problem

Reported by @chenshj73 in #38. The x402 verifier checked the token-declared `amount` against `minimumAmount` and let the EIP-191 signature cover it, but never reconciled it against the actual ERC-20 Transfer event value in the referenced transaction. A signed token from a (potentially malicious) buyer could declare any `amount` and still pass verification, then flow into `marketplace.recordPurchase({ amountUsdc })` and `marketplace.computeRevenueShares(..., amountUsdc)` — inflating revenue shares against a real but tiny on-chain transfer.

While verifying the fix, I also noticed a closely related gap: the Transfer log search matched on the `Transfer` topic and recipient topic, but never required the log to have been emitted by the canonical USDC contract. An attacker-deployed contract could emit a Transfer event to the expected recipient and pass verification. Fixed in the same change since the amount binding is meaningless without it.

## Fix

`src/services/x402-verify.ts`:
- Add per-network canonical USDC contract addresses (Base mainnet `0x833589fc…2913`, Base Sepolia `0x036cbd53…cf7e`).
- Transfer log search now requires `log.address` to equal the USDC contract for the chosen network.
- Decode the log's non-indexed `value` field (6-decimal USDC base units) as `BigInt`, require it to be `>= declaredAmountToBaseUnits(amount)`. Overpayment is still accepted.
- Drop the `receipt.to === expectedRecipient` shortcut, which bypassed the Transfer log check entirely for native-ETH-shaped receipts. (The inline comment already noted this branch was for USDC.)

`src/services/x402-verify.test.ts`:
- Test fixture now sets `log.address` and a real `data` value covering the declared amount.
- Three new cases:
  - declared 1.00 USDC vs on-chain 0.0001 USDC → reject (#38 inflation).
  - declared == on-chain → accept (exact).
  - on-chain > declared → accept (overpayment).
  - Transfer emitted by non-USDC contract → reject (fake-token).
- Updated one existing assertion to match the new (more accurate) error string.

## Test plan
- [x] `pnpm exec vitest run src/services/x402-verify.test.ts` -> 13/13 pass
- [x] `pnpm exec vitest run src/services/a2a-payment-token.test.ts` -> 4/4 pass
- [x] `pnpm exec oxfmt --check src/services/x402-verify.ts src/services/x402-verify.test.ts` -> clean
- [x] `pnpm exec oxlint src/services/x402-verify.ts src/services/x402-verify.test.ts` -> 0/0