### PR TITLE
fix(wallet): URL-encode Coinbase Pay addresses/assets JSON params

### DIFF
--- a/desktop/renderer/src/components/wallet/WalletView.tsx
+++ b/desktop/renderer/src/components/wallet/WalletView.tsx
@@ -222,10 +222,16 @@ export function WalletView() {
       // Fallback: construct URL client-side
     }
     if (address) {
-      const url =
-        network === "base-sepolia"
-          ? `https://portal.cdp.coinbase.com/products/faucet?address=${address}&network=base-sepolia`
-          : `https://pay.coinbase.com/buy?addresses={"${address}":["base"]}&assets=["USDC"]`;
+      let url: string;
+      if (network === "base-sepolia") {
+        url = `https://portal.cdp.coinbase.com/products/faucet?address=${address}&network=base-sepolia`;
+      } else {
+        const params = new URLSearchParams({
+          addresses: JSON.stringify({ [address]: ["base"] }),
+          assets: JSON.stringify(["USDC"]),
+        });
+        url = `https://pay.coinbase.com/buy?${params.toString()}`;
+      }
       window.open(url, "_blank");
     }
   };


### PR DESCRIPTION
## Summary

The `handleFundWallet` fallback in `WalletView.tsx` builds the Coinbase Pay URL by interpolating raw JSON directly into the query string:

```
https://pay.coinbase.com/buy?addresses={"0x...":["base"]}&assets=["USDC"]
```

Coinbase Pay requires `addresses` and `assets` to be **URL-encoded JSON**. Unencoded `{`, `}`, `[`, `]`, and `"` are reserved or unsafe in the query component per RFC 3986. The link works today only because permissive parsers happen to recover it — Coinbase, browsers, or intermediary proxies can (and sometimes do) reject, normalise, or partially parse it.

This PR switches to `URLSearchParams` + `JSON.stringify`, which percent-encodes the values cleanly:

```ts
const params = new URLSearchParams({
  addresses: JSON.stringify({ [address]: ["base"] }),
  assets: JSON.stringify(["USDC"]),
});
url = `https://pay.coinbase.com/buy?${params.toString()}`;
```

10 lines changed in one file. No behaviour change for the `wallet.fund` happy path — only the fallback that fires when the gateway can't return a `fundingUrl`.

## Test plan

- [ ] Block `wallet.fund` (kill gateway or stub the request to reject) → click **Fund Wallet** on a `base` wallet → confirm Coinbase Pay opens with the correct address pre-filled
- [ ] Same with a `base-sepolia` wallet → confirm the existing faucet URL still opens (unchanged)
- [ ] Inspect the opened URL: `addresses` and `assets` query params should be percent-encoded (`%7B...%7D`, `%5B...%5D`)

## Provenance

Found by AntFleet's two-model consensus review (Claude Opus 4.7 + GPT-5) against [`AntFleet/bench-bitterbot-desktop#1`](https://github.com/AntFleet/bench-bitterbot-desktop/pull/1). Companion to [#37](https://github.com/Bitterbot-AI/bitterbot-desktop/pull/37) (HIGH inbound allowlist normalization), merged 2026-05-28.
