### PR TITLE
feat: PLAN-22 Affective Goal Drive - complexity-gated auto-initiated goal workflows (Phases 0-4)

### DIFF
--- a/docs/plans/PLAN-22-affective-goal-drive.md
+++ b/docs/plans/PLAN-22-affective-goal-drive.md
@@ -1,0 +1,277 @@
+# PLAN-22: Affective Goal Drive (AGD) - Hormone-Gated Complexity Triage and Auto-Initiated Goal Workflows
+
+**Goal:** Make goal-orientation a _biological drive_ rather than a planner mode. Appraise prompt complexity at the front door of the agent loop, set the escalation threshold and decomposition depth from live cortisol/dopamine/GCCRF state, and turn every unfinished goal into Zeigarnik tension that proactive recall and the dream engine are compelled to resolve.
+**Date:** 2026-05-31
+**Status:** Draft. Awaiting review.
+
+---
+
+## Summary
+
+PLAN-16/17 shipped the entire long-horizon Task spine (store, event journal, handoff records, self-scheduling wakeup, A-MAC Judge, hormonal concurrency gate, completion notifier) and wired two auto-initiation paths (curiosity-spawn and dream-cycle bias). What is still missing is the one seam PLAN-17 explicitly punted: a pre-turn hook that looks at an inbound user prompt, decides whether it warrants a goal workflow, and creates the Task automatically. AGD adds that hook plus a pure complexity-appraisal module, binds both the escalation threshold and the decomposition depth to live hormonal/GCCRF state (the structural moat), and closes the two-way UX gap with a `task_resume_inline` tool.
+
+**What already exists (reuse, do not rebuild):** `TaskStore` CRUD + status enum + done-criteria-as-oracle (`src/tasks/store.ts`, `src/tasks/types.ts`); `EventJournal` task-tagged streams (`src/infra/event-journal.ts`); the Task Judge as both decomposition planner and completion auditor (`src/tasks/judge.ts`, `src/tasks/judge-provider.ts`); the hormonal accessor + `active-task-tracker` concurrency gate (`computeTaskConcurrency` in `src/tasks/biology.ts`); the handoff nudge (`src/tasks/handoff-nudge.ts`); the completion notifier (`src/tasks/completion-notifier.ts`); the cron isolated-agent wakeup executor (`src/cron/isolated-agent.ts`); the curiosity and dream call sites (`src/memory/curiosity-engine.ts`, `src/memory/dream-engine.ts`).
+
+**What is new:** a prerequisite Phase 0 refactor (P0.1: extract the gateway dispatch envelope into `dispatchAgentRun` with a fail-closed `applyPreTurnDecision` seam; P0.2: extract a shared `buildResumeMessage` + session/auth-carry helper) so the hook and resume tool consume primitives instead of editing the 691-line handler inline or re-implementing cross-wakeup binding; `src/tasks/complexity.ts` (pure appraisal + hormonal modulation); `src/tasks/auto-initiate.ts` (the single mutating caller); the pre-turn hook registered through that seam; a Zeigarnik-tension adapter family (E.4) in `src/tasks/biology.ts`; the `task_resume_inline` tool in `src/agents/tools/task-tool.ts`; env flags `BITTERBOT_TASKS_COMPLEXITY_GATE` and `BITTERBOT_TASKS_AUTO_INITIATE`.
+
+---
+
+## Context
+
+PLAN-17 left this gap explicitly (its own Diagnosis): "No gateway loop interceptor/hook for task-auto-initiation - prompts flow through the `agent` method, then `agentCommand()`, then the embedded runner, with no pre-turn complexity gate. Task-spawn only fires explicitly or via curiosity-engine impulse." Today a user can type "refactor the auth module across all three packages, add tests, and open a PR" and the agent will attempt the whole thing inside a single turn with no durable plan, no oracle, and no checkpoint - and if context overflows mid-way, the work dies (the handoff nudge only fires for runs already tagged with a `taskId`).
+
+The runner-up approaches converged on a small set of corrections that this plan adopts:
+
+- **Verified seam.** The architecture brief's cited line numbers were stale. The real entry is the `agent` handler in `src/gateway/server-methods/agent.ts` (the `agentHandlers` object). `agentCommand()` is invoked once, near the end of the handler (the `void agentCommand({...}, defaultRuntime, context.deps)` call), _after_ `requestedSessionKey`/`resolvedSessionKey` resolution and the `/new`/`/reset` short-circuit. The hook attaches there - not at any "line 381/phantom" location.
+- **FrugalGPT cascade.** A synchronous sub-millisecond heuristic scorer runs first; the temp=0 Judge LLM is consulted only for prompts in an ambiguous gray band. The common trivial and obviously-large cases never pay for an LLM router round-trip.
+- **Mechanical oracles preferred.** "No oracle, no serious goal" (GoalBuddy) is ported onto the existing human-readable `doneCriteria` contract, but the gate prefers a mechanical/observable oracle (test passes, file exists, tool returns, schema validates) and only falls back to the Judge LLM when no observable check is derivable.
+- **No schema churn.** The decomposition DAG serializes into the existing `task.plan` (`PlanStep[]`) plus additive `metadata` fields. No new SQLite tables.
+
+SOTA scan grounding the design:
+
+- **Complexity routing** is a live research area (FrugalGPT cascades, RouteLLM). The differentiator here is that the routing threshold is a function of internal affective state, which off-the-shelf routers do not have.
+- **ADaPT** (As-Needed Decomposition and Planning) supplies the demand-driven AND/OR recursion: attempt the largest safe slice, decompose only on failure, cap recursion depth.
+- **Zeigarnik effect** (unfinished tasks occupy memory and create resumption pressure) is the neuroscience anchor for tension-driven dream bias and proactive recall.
+- **Reflexion** supplies the failure-reflection-to-memory loop for cross-session strategy improvement.
+
+---
+
+## The Complexity Gate
+
+### Where it hooks (verified)
+
+In `src/gateway/server-methods/agent.ts`, inside the `agent` handler, after `resolvedSessionKey` is finalized (the `if (requestedSessionKey) { ... }` block that writes `nextEntry` and sets `resolvedSessionKey = canonicalSessionKey`) and after the `/new`/`/reset` short-circuit, but _before_ the `void agentCommand({...})` dispatch. The hook is a single awaited call:
+
+```ts
+// new, after sessionKey resolution, before agentCommand dispatch
+const goalDecision = await maybeInitiateGoal({
+  message, // post-attachment, post-timestamp user text
+  sessionKey: resolvedSessionKey,
+  agentId,
+  runId,
+  source: "user",
+});
+// goalDecision is a discriminated union; agentCommand still runs either way,
+// but when a task was created the first slice + an ack are threaded in via
+// extraSystemPrompt (see Goal Workflow > Intent).
+```
+
+`maybeInitiateGoal` lives in the new `src/tasks/auto-initiate.ts` and is the **only** mutating caller. The scorer itself (`src/tasks/complexity.ts`) is pure and side-effect-free, mirroring the `src/tasks/biology.ts` convention (query-only; the caller decides whether to act). The whole hook is wrapped so that any throw degrades to inline (the user's turn must never be blocked by appraisal failure).
+
+### Two-stage cascade
+
+**Stage 1 - synchronous heuristic scorer (always on, in `complexity.ts`).**
+`appraiseComplexity(prompt, ctx): ComplexityVerdict` computes a raw score in `[0,1]` from cheap features:
+
+- token/character length (long prompts skew complex);
+- count of imperative/action verbs and multi-clause structure;
+- enumeration and sequencing markers ("and then", "after that", numbered lists, "first/second");
+- estimated required-tool footprint (does it imply file edits, multi-file scope, web research, builds, shell);
+- presence of an implicit oracle (testable/observable success language: "passing tests", "PR", "deploys", "returns X");
+- project-lexicon hits (file paths, package names, repo-specific nouns);
+- optional embedding-similarity to a small bucket of known-hard past goals pulled from SAGE/episodic memory (PLAN-18). This signal is best-effort: if the memory index is unavailable the term contributes zero.
+
+Output: `ComplexityVerdict { score, signals: Signal[], suggestedDepth, route: 'inline' | 'plan' | 'decompose' }`. `signals[]` is human-readable (`{ name, value, weight }`) so every decision is inspectable.
+
+**Stage 2 - gray-band LLM self-assessment (rare).** Two thresholds `T_low`/`T_high` partition the score. Below `T_low` route is forced `inline`; above `T_high` route is `plan` or `decompose`. Only the gray band `[T_low, T_high]` (default `0.35`-`0.65`) escalates to a single temp=0 Judge-LLM classification, reusing the existing `getJudgeLlmCall()` seam (`src/tasks/judge.ts:191`) with a small `max_tokens`. No new provider, no streaming, no planner round-trip. The common trivial and obviously-large cases never call the LLM.
+
+### Biological modulation (the moat)
+
+`modulateComplexityThreshold(verdict, hormonalState, gccrfState): RoutingDecision` consumes the **same** hormonal getter that `computeTaskConcurrency` uses, via the already-wired accessor (`registerHormonalStateGetter` at `src/tasks/active-task-tracker.ts:37`, fed by `startHormonalAccessor` at boot). Direction is kept consistent with `computeTaskConcurrency` so the two never fight:
+
+- **Effective threshold:** `T_high_eff = T_high_base − dopamineTerm − gccrfCuriosityTerm + cortisolTerm`. High dopamine/GCCRF curiosity **lowers** the escalation bar (explore, decompose eagerly); high cortisol **raises** it (narrow scope, prefer inline or a single bounded slice).
+- **Decomposition depth cap:** `suggestedDepth` is multiplied up by dopamine/GCCRF and clamped down by cortisol - the ADaPT recursion cap is literally an effort-allocation knob set by affect.
+- **Fan-out:** concurrency reuses `computeTaskConcurrency` unchanged, so cortisol already shrinks active scope globally.
+- **Low arousal/energy** biases toward inline to conserve.
+
+Modulation operates **only inside** the deterministic `[T_low, T_high]` band. Hard floors and ceilings sit outside the modulated band: a micro-prompt floor guarantees that trivially short prompts can never escalate regardless of hormones, and a hard ceiling guarantees an obviously multi-step prompt is never suppressed below `plan` even under maximal cortisol. This keeps routing auditable and testable: the band moves, the rails do not.
+
+### Avoiding false triggers on simple prompts
+
+1. Hard micro-prompt floor (length + zero action-verbs + zero tool-footprint → forced `inline`, never appraised further).
+2. Stage 1 is the default exit for the vast majority of prompts; the LLM is consulted only in the gray band.
+3. The modulated threshold can only move within `[T_low, T_high]`; the floor/ceiling rails are hormone-independent.
+4. Capacity backstop: if `acquireTaskSlot` is at capacity or unavailable, a would-be task-tier prompt degrades to inline (plus a deferred curiosity note), so the gate never blocks or drops the user's request.
+5. Default-off env (`BITTERBOT_TASKS_AUTO_INITIATE`) until phase-suffixed tests land; `BITTERBOT_TASKS_COMPLEXITY_GATE` controls the appraisal independently for staged rollout.
+
+---
+
+## The Goal Workflow (Intent → Oracle → Surface → Loop → Proof)
+
+Mapped onto the existing status enum (`pending → planning → running → waiting_external → judging → {completed, failed, stopped}`) with no new lifecycle states.
+
+**Intent.** `maybeInitiateGoal` creates a Task via `TaskStore.create` with `source: "user"`, the user prompt as `goal`, and the modulated `ComplexityVerdict` (including the pinned hormonal/GCCRF snapshot) stored in `metadata`. A one-line user ack ("Starting a goal run for this - I will work it as a tracked task.") is threaded into the run via `extraSystemPrompt` so the turn remains abortable and the user is never silently switched into a background mode.
+
+**Oracle.** Creation **requires** a non-empty `doneCriteria` (the existing human-readable acceptance contract the Judge already reads as its sole pass/fail input). The gate derives it in priority order: (1) a mechanical/observable oracle if one is inferable (test command, artifact path, tool-return shape, schema); (2) failing that, the Judge LLM drafts a falsifiable oracle, surfaced to the user; (3) the in-turn agent may refine it via `task_update` before the first wakeup. Vacuous or unfalsifiable oracles are rejected at creation. This directly closes GoalBuddy's own weak-oracle failure mode.
+
+**Surface.** `task.plan` (ordered `PlanStep[]`) is the single board. The decomposition DAG serializes into `task.plan` plus additive `metadata.deps` / `metadata.group` fields - no parallel persistence layer, no schema change, and the existing `store.update` immutability rule (a `PlanStep` cannot leave `completed`, enforced at `store.ts`) is respected. The `EventJournal` task-id-tagged stream is the durable, re-readable working-memory artifact (the `state.yaml` analog) that survives cron wakeups.
+
+**Loop.** ADaPT demand-driven decomposition: the executor attempts the largest safe useful slice (bounded, explicit, verified, reversible). On failure, the Judge decomposes into AND/OR sub-steps; recursion depth is capped by the hormone-set `suggestedDepth`. Each completed slice writes a receipt as a task-id event (reusable for confidence calibration and reconsolidation). An idempotency/rollback precondition is recorded in the EventJournal before a step is eligible for retry, guarding against double-effects on replan. Long slices trigger the existing handoff nudge (`maybeNudgeTaskHandoff`, fired in `src/agents/pi-embedded-subscribe.handlers.tools.ts`) and `task_schedule_wakeup` for background continuation on the cron isolated-agent path - no new runner is introduced.
+
+**Proof.** Completion is gated by `runTaskJudge` auditing receipts against the oracle (`judging → completed` only when the oracle is satisfied, not when the plan is merely empty). `runTaskJudge` is reused twice: as a per-step verifier and as the final auditor. On `fail`/`needs_more`, a Reflexion-style reflection is written to SAGE/episodic memory so decomposition strategy improves across sessions, and the task re-opens with `source: "judge"` per the existing convention.
+
+**Promotion back to chat.** `task_resume_inline` (new) is the inverse of `task_schedule_wakeup`: it loads the task and latest handoff, marks it `running` with `currentRunId` bound to the current run, and enqueues the same resume prompt the cron wakeup would have used into the _current_ session. This closes the two-way UX gap (Phase 4a, which PLAN-17 deferred). Background→foreground completion notices already ride the wired `completion-notifier`.
+
+---
+
+## Biology Binding
+
+This is structural, not cosmetic:
+
+1. **Escalation threshold is a function of live state** - the same prompt routes to a quick inline answer under stress and to a decomposed multi-slice goal under curiosity.
+2. **Decomposition depth = ADaPT recursion cap** set by dopamine/GCCRF (raise) vs cortisol (clamp) - an effort-allocation primitive off-the-shelf routers lack.
+3. **Fan-out reuses `computeTaskConcurrency`** so cortisol literally narrows active scope; the gate and the concurrency tracker read the identical getter and never contradict.
+4. **Zeigarnik tension (new biology.ts E.4).** `computeZeigarnikTension(pendingTasks, hormonalState)` derives a tension scalar from count, age, and stall of unfinished `source:"user"` goals, weighted by hormonal state. This feeds the **existing** dream pre-weighting path (`scanPendingTasksForDream` → `computeDreamTaskAdjustments`, applied in `src/memory/dream-engine.ts`) so open loops bias Simulation/Replay dream modes, and feeds proactive recall so the system surfaces and resumes open loops unprompted. `maybeResumeFromTension()` returns a resumption candidate; the caller (dream engine / proactive recall) decides to act, keeping E.4 pure like E.1-E.3.
+5. **Curiosity-spawn is a sibling initiation path.** `maybeSpawnTaskFromCuriosity` (`src/memory/curiosity-engine.ts`) and `maybeInitiateGoal` both write into the same Task lifecycle; no second pipeline.
+6. **Consolidation.** Completed goal DAGs are dream-harvested into reusable plan templates (the PLAN-20 interceptor / case-based-HTN seam), giving a spacing/consolidation analog.
+
+All tension-driven resumption reuses the existing 5-minute handoff-nudge throttle pattern and decays tension on user dismissal, so the drive never becomes a nagging loop.
+
+---
+
+## Phased Implementation
+
+> **Sequencing constraint (review correction).** Phase 3 (the hook) and Phase 5 (the resume tool) must not be wired into the gateway as-is; each needs a primitive extracted first so it cannot break the existing run path. Verified against HEAD: `agentCommand` (`src/commands/agent.ts:205`) is already a widely shared entrypoint (~9 call sites across `agent-via-gateway.ts`, `openai-http.ts`, `boot.ts`, `server-node-events.ts`, `openresponses-http.ts`, and the gateway handler), so it is not the gap. The gap is the gateway _dispatch envelope_ - runId generation, the `context.dedupe` ack (`agent.ts:519`/`524`), and the two-phase `respond` (`agent.ts:524` then `agent.ts:578`) - which is inlined in the 691-line handler and partly duplicated in `server-node-events.ts`. Critically the handler acks `{status:"accepted"}` at line 524 _before_ the `void agentCommand(...)` fire-and-forget at line 528: a hook before the ack delays it, and a hook between the ack and the dispatch runs outside any error boundary where a throw silently kills the run. Phase 0 builds both prerequisites; Phases 3 and 5 then consume them.
+
+### Phase 0 - Prerequisite primitives (refactor, zero behavior change)
+
+**Scope.** Two extractions, no new behavior, fully covered by the existing gateway/wakeup tests.
+
+- **P0.1 `dispatchAgentRun()` + `applyPreTurnDecision` seam (prereq for Phase 3).** Extract the dispatch envelope (runId, `context.dedupe` ack, two-phase `respond`, session canonicalization, outbound-target resolution) out of `agent.ts` into one reusable function; collapse the `server-node-events.ts` duplication onto it. Add a typed, fail-closed `applyPreTurnDecision(payload) -> payload` interceptor invoked _after_ the ack, wrapped so any throw or timeout logs and returns the unmodified payload. The hook can then only augment `message`/`extraSystemPrompt`/`runContext`; it can never delay the ack or kill the run. This makes "cannot break the gateway" structural rather than convention.
+- **P0.2 shared `buildResumeMessage` + session/auth-carry helper (prereq for Phase 5).** Extract the resume-prompt builder and the session-key/auth carry currently inside `task_schedule_wakeup` so both the existing wakeup path and the new `task_resume_inline` tool share one implementation, instead of the tool re-implementing cross-wakeup session binding.
+
+**Files touched:** `src/gateway/server-methods/agent.ts`, `src/gateway/server-node-events.ts`, `src/agents/tools/task-tool.ts` (extract only).
+**Files added:** `src/gateway/server-methods/dispatch-agent-run.ts` (+ test), `src/tasks/resume-message.ts` (+ test).
+**Tests:** existing gateway agent tests pass byte-identically against `dispatchAgentRun`; the no-op `applyPreTurnDecision` is transparent; a throwing/timing-out decision falls through to the unmodified payload; `buildResumeMessage` parity between wakeup and inline callers.
+**Migration:** none.
+
+### Phase 1 - Pure complexity appraisal (`complexity.ts`)
+
+**Scope.** Stage-1 heuristic scorer + the modulation function, both pure. Discriminated `RoutingDecision` with `reasons[]`. No hook, no mutation, no LLM call yet (gray band returns `needs_llm: true` for the caller to resolve later).
+**Files added:** `src/tasks/complexity.ts`, `src/tasks/complexity.test.ts`.
+**Files touched:** none.
+**Tests:** feature scoring on a corpus of trivial/medium/large prompts; floor/ceiling rails; modulation moves the band in the right direction for high-cortisol vs high-dopamine snapshots; modulation never crosses the rails.
+**Migration:** none.
+
+### Phase 2 - Auto-initiate caller + gray-band LLM (`auto-initiate.ts`)
+
+**Scope.** `maybeInitiateGoal` (the single mutating caller): runs Stage 1, resolves the gray band via `getJudgeLlmCall()` (temp=0, bounded tokens), reads the hormonal/GCCRF getters, derives/validates the oracle (mechanical-first, Judge-fallback, reject vacuous), creates the Task with the pinned snapshot in `metadata`, writes the creation event to the EventJournal, and returns a discriminated `{ mode: 'inline' } | { mode: 'task', taskId, ack, firstSlice }`. Capacity backstop via `acquireTaskSlot`.
+**Files added:** `src/tasks/auto-initiate.ts`, `src/tasks/auto-initiate.test.ts`.
+**Files touched:** none yet (hook lands in Phase 3).
+**Tests:** trivial → inline; large → task with valid oracle; gray band consults the (mocked) Judge once; vacuous oracle rejected; at-capacity degrades to inline + deferred note; every decision recorded in `metadata` + journal.
+**Migration:** none (uses existing `metadata` JSON column).
+
+### Phase 3 - Pre-turn hook in the agent loop
+
+**Scope.** Register `maybeInitiateGoal` as the `applyPreTurnDecision` implementation from P0.1 (runs after the client ack, inside the fail-closed wrapper), not as a raw inline call in the handler. Thread the ack + first slice into `extraSystemPrompt` via the payload augmentation the seam returns. Gate behind `BITTERBOT_TASKS_AUTO_INITIATE` (default off) and `BITTERBOT_TASKS_COMPLEXITY_GATE` (default on for appraisal-only telemetry). Fail-open is now structural (the seam swallows throws/timeouts), not a hand-written try/catch.
+**Files touched:** `src/tasks/auto-initiate.ts` (register the seam); the handler itself is unchanged beyond Phase 0.
+**Files added:** `src/gateway/server-methods/agent.auto-initiate.test.ts`.
+**Tests:** hook fires only when env on; inline prompts pass through unchanged (byte-identical `agentCommand` args); thrown appraisal degrades to inline; ack threaded for task-tier; `/new`/`/reset` path is never appraised.
+**Migration:** none.
+
+### Phase 4 - Zeigarnik tension adapters (biology.ts E.4)
+
+**Scope.** Add `computeZeigarnikTension` and `maybeResumeFromTension` as pure adapters. Wire the tension term into the existing dream pre-weighting (`computeDreamTaskAdjustments` consumer in `dream-engine.ts`) and into proactive recall, both throttled by the existing 5-minute pattern and with decay-on-dismissal. Gate behind `BITTERBOT_DREAM_TASK_BIAS` (existing) extended to cover tension.
+**Files touched:** `src/tasks/biology.ts`, `src/memory/dream-engine.ts` (consumer only), proactive-recall call site.
+**Files added:** `src/tasks/biology.phase4.test.ts` (note the spelled-out `phase4` per the repo's E.4 test-naming convention).
+**Tests:** tension scales with count/age/stall and hormonal state; zero pending → zero adjustment; resumption respects throttle and decays on dismissal.
+**Migration:** none.
+
+### Phase 5 - `task_resume_inline` tool (two-way UX)
+
+**Scope.** New agent tool in `src/agents/tools/task-tool.ts`: load task + latest handoff, mark `running` with `currentRunId` bound to the current run, enqueue the resume prompt into the current session using the shared `buildResumeMessage` + session/auth-carry helper from P0.2 (not a re-implementation). This is the riskiest item because of session-key/auth binding across wakeups, which is exactly why P0.2 extracts that binding into one tested helper first. Register in `src/agents/bitterbot-tools.ts`.
+**Files touched:** `src/agents/tools/task-tool.ts`, `src/agents/bitterbot-tools.ts`.
+**Files added:** `src/agents/tools/task-tool.phase5.test.ts`.
+**Tests:** resume binds the correct session/run; refuses on terminal tasks; idempotent re-call does not double-enqueue; auth/session-key carried across the wakeup boundary.
+**Migration:** none.
+
+---
+
+## Risks and Mitigations
+
+- **Front-door latency/cost on every prompt.** Stage-1 heuristic first + hard micro-prompt floor; only the gray band hits one temp=0 LLM call. Telemetry on gray-band hit rate; tune `T_low`/`T_high` if the band is too wide.
+- **Non-deterministic, hard-to-debug routing from hormonal modulation.** Pin the hormonal/GCCRF snapshot and the full `signals[]`/`reasons[]` into `ComplexityVerdict` metadata and the EventJournal; keep deterministic floor/ceiling rails around the modulated band so tests assert on the rails, not the band.
+- **Weak/unfalsifiable oracle silently defeats the proof loop.** Require `doneCriteria` at creation; prefer mechanical oracles; have the Judge reject vacuous ones; allow in-turn refinement before the first wakeup.
+- **Goal sprawl under chronic high curiosity (AutoGPT failure mode).** Recursion-depth + cost/time budgets per goal; reuse `computeTaskConcurrency` as a global throttle; curiosity-spawn already dedupes by topic with a 7-day lookback.
+- **Tension-driven dreams/recall becoming nagging or looping.** Reuse the 5-minute handoff-nudge throttle; decay tension on user dismissal.
+- **`task_resume_inline` session/auth binding across wakeups is genuinely new plumbing.** Scoped as its own phase with dedicated auth-carry tests.
+- **Stale line numbers in source briefs.** All seams in this plan were re-validated against HEAD: the hook attaches in the `agent` handler before the `agentCommand` dispatch; `registerHormonalStateGetter` is at `active-task-tracker.ts:37`; `getJudgeLlmCall` at `judge.ts:191`. Re-validate again at implementation time.
+
+## Non-Goals
+
+- No new runtime, scheduler, or persistence layer; execution rides the existing cron isolated-agent + status enum + EventJournal + handoffs.
+- No new SQLite tables or migration; the DAG lives in `task.plan` + additive `metadata`.
+- No auto-spawning of parallel sub-agents; parallel plans only _report_ disjoint read/write scopes (human-gated fan-out).
+- No self-consistency Judge voting in this plan (deferred, consistent with PLAN-17 Phase 1).
+- No wallet/bounty involvement; P2P payout remains Victor-only and untouched.
+- No model-fallback-chain edits (that is PLAN-17 Phase 5 territory).
+
+---
+
+## What the user gets when this ships
+
+Type a one-liner like "audit the access-control normalization, write a regression test, and confirm it passes" and the agent recognizes the complexity, states it is opening a tracked goal, derives a falsifiable oracle (the test passes), works the largest safe slice, hands off and self-schedules if context runs tight, and reports back when the oracle is satisfied - and if the user later says "what about that audit?", the open loop is already surfaced because it was tension the system was driven to resolve. Under stress (high cortisol) the same one-liner gets a fast, narrow answer instead; under curiosity (high dopamine/GCCRF) it decomposes more eagerly. The triage is the biology, not a toggle.
+
+---
+
+Relevant files (all absolute):
+
+- New: `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/complexity.ts`, `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/auto-initiate.ts`
+- Edit: `/mnt/d/Bitterbot/bitterbot-desktop/src/gateway/server-methods/agent.ts` (hook before the `agentCommand` dispatch), `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/biology.ts` (E.4), `/mnt/d/Bitterbot/bitterbot-desktop/src/memory/dream-engine.ts` (tension consumer), `/mnt/d/Bitterbot/bitterbot-desktop/src/agents/tools/task-tool.ts` + `/mnt/d/Bitterbot/bitterbot-desktop/src/agents/bitterbot-tools.ts` (`task_resume_inline`)
+- Reuse seams: `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/store.ts`, `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/types.ts`, `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/judge.ts` (`getJudgeLlmCall` at :191), `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/active-task-tracker.ts` (`registerHormonalStateGetter` at :37, `acquireTaskSlot`), `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/handoff-nudge.ts`, `/mnt/d/Bitterbot/bitterbot-desktop/src/tasks/completion-notifier.ts`, `/mnt/d/Bitterbot/bitterbot-desktop/src/cron/isolated-agent.ts`, `/mnt/d/Bitterbot/bitterbot-desktop/src/infra/event-journal.ts`
+
+Suggested filename for this plan: `/mnt/d/Bitterbot/bitterbot-desktop/research/plans/PLAN-22-AFFECTIVE-GOAL-DRIVE.md`
+
+---
+
+## Addendum: Review Hardening (must-fix before implementation)
+
+An adversarial fit-check against the live architecture flagged four hardening
+requirements. None are architectural blockers; all must be folded into the
+relevant phases before code lands.
+
+### 1. Hard latency budget on the hot path
+
+The pre-turn appraisal sits on every user turn. Stage 1 (heuristic) is sub-ms,
+but the gray-band Judge consultation must run under a strict timeout
+(target 800ms) and, on timeout, degrade to inline (treat as below-threshold).
+The whole hook is wrapped so any throw or timeout never blocks the turn.
+
+### 2. Immediate user-facing opt-out at auto-initiation
+
+When a turn is converted into a goal workflow, the acknowledgement must offer an
+obvious, immediate escape hatch ("reply 'just answer' to skip the plan"), not
+only the `BITTERBOT_TASKS_AUTO_INITIATE` env flag. Auto-initiation must never be
+silent.
+
+### 3. Deterministic override for reproducibility
+
+Hormone-gated thresholds make behavior state-dependent and bug reports hard to
+reproduce. Provide a deterministic override (fixed threshold via env/flag for
+tests and support repro) and always log the appraised score, the active
+hormonal modifiers, and the final decision so any initiation is explainable.
+
+### 4. False-positive regression test (highest-risk)
+
+A long-but-simple prompt (a pasted error log, a large code block, a quoted
+document) must NOT trigger a goal workflow. This is the top regression risk and
+needs an explicit end-to-end test, plus gate precision/recall telemetry so the
+threshold can be tuned post-launch.
+
+### Duplication to resolve during design
+
+- Oracle derivation partly reinvents the Judge's existing job. judge.ts already owns done-criteria evaluation as 'the sole pass/fail contract' (buildTaskJudgePrompt/parseTaskJudgeResponse/runTaskJudge). The plan's Stage-2 'Judge LLM drafts a falsifiable oracle' and 'Judge rejects vacuous oracles' adds a NEW judge call mode (oracle-authoring + oracle-validation) that judge.ts does not currently expose. This is not reuse of getJudgeLlmCall as claimed; it is a second prompt/contract bolted onto the judge seam. Either extend judge.ts deliberately (with its own phase + tests) or stop describing it as a free reuse.
+- The 'mechanical/observable oracle' inference (test command, artifact path, tool-return shape, schema) is brand-new capability with no home in src/tasks. doneCriteria is explicitly a human-readable string contract per the conventions (types.ts), not a structured machine-checkable oracle. The plan smuggles a structured-oracle type into a string field and calls it 'no schema churn' - that is a real new abstraction, not reuse.
+- Zeigarnik tension (E.4) partly duplicates scanPendingTasksForDream/computeDreamTaskAdjustments (E.2), which ALREADY pre-weights dream modes from pending tasks (Simulation +20%, Replay +10% per dream-engine.ts:608-641). computeZeigarnikTension(pendingTasks, hormonalState) reads the same store-of-pending-tasks for the same dream consumer. The plan should state whether E.4 REPLACES the E.2 adjustment math or stacks on top of it; as written, two functions feed the same dream weighting with overlapping inputs and undefined composition.
+- Length/action-verb/enumeration heuristic scoring overlaps conceptually with what curiosity-engine already does to decide novelty/alignment before spawning a task (novelty 0.6 / alignment 0.4 gates). Two different scalar-scoring front ends now both decide 'is this worth a task'. The plan asserts they are 'siblings into the same lifecycle' but does not address dedup BETWEEN them: a curiosity-spawned task and a complexity-gated task for the same user intent can both fire.
+- embedding-similarity to 'known-hard past goals pulled from SAGE/episodic memory' reinvents a retrieval the SAGE/proactive-recall layer (PLAN-18) already performs. Pulling a 'small bucket of known-hard past goals' is an undefined new query path; the plan hand-waves it as best-effort but specifies no actual SAGE API it calls.
+
+### Integration friction to confirm
+
+- Front-door hook placement fights the existing entry contract. agentCommand is dispatched with `void agentCommand(...)` (line 528) - fire-and-forget, NOT awaited. The plan inserts `await maybeInitiateGoal(...)` immediately before it. That makes the previously non-blocking front door block on appraisal (and, in the gray band, on a temp=0 Judge LLM round-trip) for EVERY qualifying prompt. The try/catch-degrades-to-inline mitigation does not remove the latency for the success path; it only handles throws. This is a real regression to interactive turn latency that the 'sub-millisecond Stage 1' framing obscures because the gray band is explicitly an LLM call on the hot path.
+- extraSystemPrompt threading conflicts with the actual call shape. agent.ts passes `extraSystemPrompt: request.extraSystemPrompt` (line 558) - it forwards the CALLER-supplied value verbatim. To inject the ack + first slice the hook must override/merge request.extraSystemPrompt, which silently discards or concatenates a client-provided prompt. The plan says 'threaded in via extraSystemPrompt' without specifying merge semantics; this will collide with any client that already sets it.
+- The agentId variable is re-derived and shadowed inside the sessionKey block (const agentId = resolveAgentIdFromSessionKey(canonicalSessionKey) at line 428 shadows the outer agentId). The hook's `agentId` argument is ambiguous about which scope it reads. A hook placed 'before agentCommand dispatch' sits after this shadowing; the plan's pseudo-code passes a bare `agentId` and `runId` without acknowledging the shadow or where runId is bound.
+- Biology purity convention vs. the hook doing mutation+LLM+journal. The repo convention is strict: biology.ts adapters are pure, query-only, callers decide to act. The plan honors this for complexity.ts but auto-initiate.ts becomes a heavy side-effecting orchestrator (LLM call, oracle validation, TaskStore.create, EventJournal write, acquireTaskSlot) living in src/tasks/ alongside the pure adapters. That is a new category of module in src/tasks (a mutating orchestrator) - it belongs architecturally closer to the gateway/command layer or needs explicit justification, otherwise it muddies the 'src/tasks = pure adapters + store + judge' separation.
+- task_resume_inline 'enqueue the resume prompt into the current session' has no demonstrated enqueue primitive. completion-notifier enqueues system events to task.agentSessionKey (background->foreground). Resume-inline needs to inject into the CURRENTLY RUNNING foreground run - a different direction with no existing seam. The plan calls it 'the inverse of task_schedule_wakeup' but schedule_wakeup writes a cron payload; there is no in-session injection API. This is the single biggest unproven plumbing item and the plan correctly flags it as risky but understates that the mechanism does not exist at all, not merely that auth-binding is hard.
+- binding currentRunId 'to the current run' from inside a tool call: the tool executes mid-run inside the embedded runner; marking the task running with currentRunId = the in-flight run, then enqueuing a resume prompt into the same session, risks re-entrancy / a run resuming itself. No guard described against the resume prompt re-triggering the complexity gate (which would create a task FROM a task-resume prompt). Loop risk between the front-door gate and resume-inline is unaddressed.
+- Capacity backstop uses acquireTaskSlot at the front door, but acquireTaskSlot's lifecycle is currently owned by cron/isolated-agent (acquire before wakeup, release-finally). Acquiring a slot synchronously in the gateway agent handler introduces a SECOND acquirer with a different release path. If maybeInitiateGoal acquires a slot to test capacity, when/where is it released? A check-without-acquire (peek) is needed, not acquireTaskSlot, or you leak slots on the inline-degrade path.

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -49,6 +49,7 @@ import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import { applyPreTurnDecision } from "./pre-turn-decision.js";
 import { sessionsHandlers } from "./sessions.js";
 
 const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
@@ -525,9 +526,17 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
+    // PLAN-22 P0.1: fail-closed pre-turn decision seam. Runs after the ack,
+    // before dispatch; a no-op unless a decider is registered (Phase 3). Any
+    // throw/timeout/malformed result degrades to the unmodified payload.
+    const preTurn = await applyPreTurnDecision(
+      { message: message ?? "", extraSystemPrompt: request.extraSystemPrompt },
+      { sessionKey: resolvedSessionKey ?? null, agentId, runId, channel: resolvedChannel ?? "" },
+    );
+
     void agentCommand(
       {
-        message,
+        message: preTurn.message,
         images,
         to: resolvedTo,
         sessionId: resolvedSessionId,
@@ -555,7 +564,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         messageChannel: resolvedChannel,
         runId,
         lane: request.lane,
-        extraSystemPrompt: request.extraSystemPrompt,
+        extraSystemPrompt: preTurn.extraSystemPrompt,
         inputProvenance,
       },
       defaultRuntime,

--- a/src/gateway/server-methods/auto-initiate-decider.test.ts
+++ b/src/gateway/server-methods/auto-initiate-decider.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PreTurnContext, PreTurnPayload } from "./pre-turn-decision.js";
+import { buildAutoInitiationDecider } from "./auto-initiate-decider.js";
+
+const CTX: PreTurnContext = { sessionKey: "s1", agentId: "a1", runId: "r1", channel: "web" };
+const BASE: PreTurnPayload = {
+  message: "refactor everything and open a PR",
+  extraSystemPrompt: undefined,
+};
+
+const taskDecision = {
+  mode: "task" as const,
+  taskId: "task-7",
+  ack: "Started task task-7. Reply 'just answer' to skip.",
+  firstSlice: "You are working on task task-7. Goal: refactor everything.",
+  oracleKind: "mechanical" as const,
+  verdict: {} as never,
+};
+const inlineDecision = { mode: "inline" as const, reason: "below", verdict: {} as never };
+
+describe("buildAutoInitiationDecider", () => {
+  it("is a no-op when both flags are off", async () => {
+    const initiate = vi.fn();
+    const decider = buildAutoInitiationDecider({
+      autoEnabled: () => false,
+      gateEnabled: () => false,
+      modulators: () => ({}),
+      initiate: initiate as never,
+    });
+    const out = await decider(BASE, CTX);
+    expect(out).toEqual(BASE);
+    expect(initiate).not.toHaveBeenCalled();
+  });
+
+  it("appraises but does not create or mutate in telemetry-only mode (gate on, auto off)", async () => {
+    const initiate = vi.fn();
+    const decider = buildAutoInitiationDecider({
+      autoEnabled: () => false,
+      gateEnabled: () => true,
+      modulators: () => ({}),
+      initiate: initiate as never,
+    });
+    const out = await decider(BASE, CTX);
+    expect(out).toEqual(BASE);
+    expect(initiate).not.toHaveBeenCalled();
+  });
+
+  it("leaves the payload unchanged when the decision is inline (auto on)", async () => {
+    const initiate = vi.fn(async () => inlineDecision);
+    const decider = buildAutoInitiationDecider({
+      autoEnabled: () => true,
+      gateEnabled: () => true,
+      modulators: () => ({ cortisol: 0.1, dopamine: 0.2 }),
+      initiate: initiate as never,
+    });
+    const out = await decider(BASE, CTX);
+    expect(out).toEqual(BASE);
+    expect(initiate).toHaveBeenCalledTimes(1);
+  });
+
+  it("augments extraSystemPrompt with the first slice and ack on a task decision", async () => {
+    const initiate = vi.fn(async () => taskDecision);
+    const decider = buildAutoInitiationDecider({
+      autoEnabled: () => true,
+      gateEnabled: () => true,
+      modulators: () => ({}),
+      initiate: initiate as never,
+    });
+    const out = await decider(BASE, CTX);
+    expect(out.message).toBe(BASE.message); // message untouched
+    expect(out.extraSystemPrompt).toContain(taskDecision.firstSlice);
+    expect(out.extraSystemPrompt).toContain(taskDecision.ack);
+  });
+
+  it("appends to an existing extraSystemPrompt rather than replacing it", async () => {
+    const initiate = vi.fn(async () => taskDecision);
+    const decider = buildAutoInitiationDecider({
+      autoEnabled: () => true,
+      gateEnabled: () => true,
+      modulators: () => ({}),
+      initiate: initiate as never,
+    });
+    const out = await decider({ message: BASE.message, extraSystemPrompt: "PRIOR" }, CTX);
+    expect(out.extraSystemPrompt?.startsWith("PRIOR")).toBe(true);
+    expect(out.extraSystemPrompt).toContain(taskDecision.firstSlice);
+  });
+
+  it("passes the session key and modulators through to the initiator", async () => {
+    const initiate = vi.fn(async () => inlineDecision);
+    const decider = buildAutoInitiationDecider({
+      autoEnabled: () => true,
+      gateEnabled: () => true,
+      modulators: () => ({ cortisol: 0.9 }),
+      initiate: initiate as never,
+    });
+    await decider(BASE, CTX);
+    expect(initiate).toHaveBeenCalledWith(
+      { prompt: BASE.message, agentSessionKey: "s1", source: "user" },
+      { modulators: { cortisol: 0.9 } },
+    );
+  });
+});

--- a/src/gateway/server-methods/auto-initiate-decider.ts
+++ b/src/gateway/server-methods/auto-initiate-decider.ts
@@ -1,0 +1,108 @@
+/**
+ * Auto-initiation pre-turn decider (PLAN-22 Phase 3).
+ *
+ * Bridges the pure complexity gate (Phase 1/2) to the fail-closed seam
+ * (Phase 0). Registered once at gateway task-subsystem startup; the seam
+ * invokes it after the client ack and before dispatch.
+ *
+ * Two env flags gate behaviour:
+ *   - BITTERBOT_TASKS_COMPLEXITY_GATE (default ON): appraise + log telemetry
+ *     only. No task is created and the payload is never mutated.
+ *   - BITTERBOT_TASKS_AUTO_INITIATE (default OFF): actually create the Task
+ *     and augment the run's extraSystemPrompt with the first slice + ack.
+ *
+ * The decider only ever augments `extraSystemPrompt`; combined with the
+ * seam's fail-closed wrapper, it cannot block or alter the run on any
+ * failure path.
+ */
+
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { maybeInitiateGoal } from "../../tasks/auto-initiate.js";
+import { appraiseComplexity, type ComplexityModulators } from "../../tasks/complexity.js";
+import { peekHormonalAccessorState } from "../../tasks/hormonal-accessor.js";
+import { registerPreTurnDecider, type PreTurnDecider } from "./pre-turn-decision.js";
+
+const log = createSubsystemLogger("tasks/auto-initiate-decider");
+
+/** Appraisal-only telemetry, on by default. Disable with "0". */
+export function isComplexityGateEnabled(): boolean {
+  return process.env.BITTERBOT_TASKS_COMPLEXITY_GATE !== "0";
+}
+
+/** Actual task creation, off by default. Enable with "1" / "true". */
+export function isAutoInitiateEnabled(): boolean {
+  const v = process.env.BITTERBOT_TASKS_AUTO_INITIATE;
+  return v === "1" || v === "true";
+}
+
+/**
+ * Map the live hormonal snapshot into the gate's modulators. GCCRF curiosity
+ * is not yet plumbed here; omitted modulators are treated as neutral, so the
+ * gate degrades gracefully to the cortisol/dopamine signals.
+ */
+export function readModulators(): ComplexityModulators {
+  const h = peekHormonalAccessorState();
+  if (!h) {
+    return {};
+  }
+  return { cortisol: h.cortisol, dopamine: h.dopamine };
+}
+
+export interface AutoInitiationDeciderDeps {
+  autoEnabled?: () => boolean;
+  gateEnabled?: () => boolean;
+  modulators?: () => ComplexityModulators;
+  initiate?: typeof maybeInitiateGoal;
+}
+
+/** Build the decider closure (deps injectable for unit testing). */
+export function buildAutoInitiationDecider(deps: AutoInitiationDeciderDeps = {}): PreTurnDecider {
+  const autoEnabled = deps.autoEnabled ?? isAutoInitiateEnabled;
+  const gateEnabled = deps.gateEnabled ?? isComplexityGateEnabled;
+  const readMods = deps.modulators ?? readModulators;
+  const initiate = deps.initiate ?? maybeInitiateGoal;
+
+  return async (payload, ctx) => {
+    const auto = autoEnabled();
+    const gate = gateEnabled();
+    if (!auto && !gate) {
+      return payload;
+    }
+
+    const modulators = readMods();
+
+    if (!auto) {
+      // Telemetry only: appraise (pure), log, never create or mutate.
+      const verdict = appraiseComplexity(payload.message, modulators);
+      if (verdict.tier !== "inline") {
+        log.debug(
+          `complexity gate (telemetry): tier=${verdict.tier} score=${verdict.score.toFixed(3)} thresholds=[${verdict.thresholds.low.toFixed(2)},${verdict.thresholds.high.toFixed(2)}]`,
+        );
+      }
+      return payload;
+    }
+
+    const decision = await initiate(
+      { prompt: payload.message, agentSessionKey: ctx.sessionKey, source: "user" },
+      { modulators },
+    );
+    if (decision.mode !== "task") {
+      return payload;
+    }
+
+    const slice = `${decision.firstSlice}\n\nBegin your reply by telling the user: ${decision.ack}`;
+    const extraSystemPrompt = payload.extraSystemPrompt
+      ? `${payload.extraSystemPrompt}\n\n${slice}`
+      : slice;
+    log.info(`auto-initiation augmented run for task ${decision.taskId}`);
+    return { message: payload.message, extraSystemPrompt };
+  };
+}
+
+/** Register the auto-initiation decider with the pre-turn seam. */
+export function registerAutoInitiation(deps?: AutoInitiationDeciderDeps): void {
+  registerPreTurnDecider(buildAutoInitiationDecider(deps));
+  log.info(
+    `auto-initiation decider registered (gate=${isComplexityGateEnabled()} auto=${isAutoInitiateEnabled()})`,
+  );
+}

--- a/src/gateway/server-methods/pre-turn-decision.test.ts
+++ b/src/gateway/server-methods/pre-turn-decision.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyPreTurnDecision,
+  hasPreTurnDecider,
+  registerPreTurnDecider,
+  type PreTurnContext,
+  type PreTurnPayload,
+} from "./pre-turn-decision.js";
+
+const CTX: PreTurnContext = { sessionKey: "s1", agentId: "a1", runId: "r1", channel: "web" };
+const BASE: PreTurnPayload = { message: "hello", extraSystemPrompt: undefined };
+
+afterEach(() => registerPreTurnDecider(null));
+
+describe("applyPreTurnDecision (fail-closed seam)", () => {
+  it("returns the payload unchanged when no decider is registered", async () => {
+    expect(hasPreTurnDecider()).toBe(false);
+    const out = await applyPreTurnDecision(BASE, CTX);
+    expect(out).toEqual(BASE);
+  });
+
+  it("applies an augmenting decider", async () => {
+    registerPreTurnDecider((p) => ({ ...p, extraSystemPrompt: "first slice" }));
+    const out = await applyPreTurnDecision(BASE, CTX);
+    expect(out.message).toBe("hello");
+    expect(out.extraSystemPrompt).toBe("first slice");
+  });
+
+  it("supports async deciders", async () => {
+    registerPreTurnDecider(async (p) => ({ ...p, message: `${p.message}!` }));
+    const out = await applyPreTurnDecision(BASE, CTX);
+    expect(out.message).toBe("hello!");
+  });
+
+  it("passes the context through to the decider", async () => {
+    const spy = vi.fn((p: PreTurnPayload) => p);
+    registerPreTurnDecider(spy);
+    await applyPreTurnDecision(BASE, CTX);
+    expect(spy).toHaveBeenCalledWith(BASE, CTX);
+  });
+
+  it("degrades to the original payload when the decider throws", async () => {
+    registerPreTurnDecider(() => {
+      throw new Error("boom");
+    });
+    const out = await applyPreTurnDecision(BASE, CTX);
+    expect(out).toEqual(BASE);
+  });
+
+  it("degrades to the original payload when the decider rejects", async () => {
+    registerPreTurnDecider(async () => {
+      throw new Error("async boom");
+    });
+    const out = await applyPreTurnDecision(BASE, CTX);
+    expect(out).toEqual(BASE);
+  });
+
+  it("degrades to the original payload when the decider exceeds the timeout", async () => {
+    registerPreTurnDecider(
+      () =>
+        new Promise<PreTurnPayload>((resolve) =>
+          setTimeout(() => resolve({ message: "late" }), 50),
+        ),
+    );
+    const out = await applyPreTurnDecision(BASE, CTX, { timeoutMs: 5 });
+    expect(out).toEqual(BASE);
+  });
+
+  it("degrades to the original payload when the decider returns a malformed value", async () => {
+    registerPreTurnDecider(() => ({ notMessage: true }) as unknown as PreTurnPayload);
+    const out = await applyPreTurnDecision(BASE, CTX);
+    expect(out).toEqual(BASE);
+  });
+});

--- a/src/gateway/server-methods/pre-turn-decision.ts
+++ b/src/gateway/server-methods/pre-turn-decision.ts
@@ -28,7 +28,7 @@ export interface PreTurnContext {
   sessionKey: string | null;
   agentId: string;
   runId: string;
-  channel: string;
+  channel: string | undefined;
 }
 
 export type PreTurnDecider = (

--- a/src/gateway/server-methods/pre-turn-decision.ts
+++ b/src/gateway/server-methods/pre-turn-decision.ts
@@ -1,0 +1,100 @@
+/**
+ * Fail-closed pre-turn decision seam (PLAN-22 Phase 0, P0.1).
+ *
+ * The gateway `agent` handler acks `{status:"accepted"}` to the client and
+ * then fire-and-forgets the run via `agentCommand`. This module provides the
+ * one safe place to influence that run *after* the ack and *before* the
+ * dispatch: a registered decider may augment the message and the system
+ * prompt (PLAN-22 Phase 3 registers the complexity gate here).
+ *
+ * The wrapper is the structural "cannot break the gateway" guarantee:
+ *   - No decider registered -> returns the payload unchanged.
+ *   - The decider throws -> returns the original payload.
+ *   - The decider exceeds the timeout -> returns the original payload.
+ *   - The decider returns a malformed payload -> returns the original.
+ * In every failure mode the run proceeds exactly as it would have without
+ * the seam. The decider can only ever augment; it can never block or fail
+ * the turn, and (because it runs after the ack) it cannot delay the ack.
+ */
+
+export interface PreTurnPayload {
+  /** The user message that will be dispatched to the agent run. */
+  message: string;
+  /** Extra system prompt threaded into the run (e.g. a goal first-slice). */
+  extraSystemPrompt?: string;
+}
+
+export interface PreTurnContext {
+  sessionKey: string | null;
+  agentId: string;
+  runId: string;
+  channel: string;
+}
+
+export type PreTurnDecider = (
+  payload: PreTurnPayload,
+  ctx: PreTurnContext,
+) => Promise<PreTurnPayload> | PreTurnPayload;
+
+/** Hard timeout on the decider so it can never stall the dispatch. */
+export const DEFAULT_PRE_TURN_TIMEOUT_MS = 800;
+
+let decider: PreTurnDecider | null = null;
+
+/** Register (or clear, with null) the pre-turn decider. Last writer wins. */
+export function registerPreTurnDecider(fn: PreTurnDecider | null): void {
+  decider = fn;
+}
+
+/** Test/introspection helper. */
+export function hasPreTurnDecider(): boolean {
+  return decider != null;
+}
+
+function isValidPayload(value: unknown): value is PreTurnPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("pre-turn decider timed out")), ms);
+    timer.unref?.();
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Apply the registered pre-turn decision. Always resolves; never rejects.
+ * Returns the (possibly augmented) payload, or the original on any failure.
+ */
+export async function applyPreTurnDecision(
+  payload: PreTurnPayload,
+  ctx: PreTurnContext,
+  opts: { timeoutMs?: number } = {},
+): Promise<PreTurnPayload> {
+  const fn = decider;
+  if (!fn) {
+    return payload;
+  }
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_PRE_TURN_TIMEOUT_MS;
+  try {
+    const result = await withTimeout(Promise.resolve(fn(payload, ctx)), timeoutMs);
+    return isValidPayload(result) ? result : payload;
+  } catch {
+    // Fail-closed: any throw or timeout degrades to the unmodified payload.
+    return payload;
+  }
+}

--- a/src/gateway/server-methods/pre-turn-decision.ts
+++ b/src/gateway/server-methods/pre-turn-decision.ts
@@ -26,7 +26,7 @@ export interface PreTurnPayload {
 
 export interface PreTurnContext {
   sessionKey: string | null;
-  agentId: string;
+  agentId: string | undefined;
   runId: string;
   channel: string | undefined;
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -63,6 +63,7 @@ import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import { GATEWAY_EVENTS, listGatewayMethods } from "./server-methods-list.js";
 import { coreGatewayHandlers } from "./server-methods.js";
+import { registerAutoInitiation } from "./server-methods/auto-initiate-decider.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
 import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
@@ -257,6 +258,8 @@ export async function startGatewayServer(
   // concurrency gate. Refresh interval 30s; disable with
   // BITTERBOT_TASKS_HORMONAL_GATE=0 to fall back to the baseline policy.
   startHormonalAccessor(cfgAtStart);
+  // PLAN-22 Phase 3: register the complexity gate as the pre-turn decider.
+  registerAutoInitiation();
 
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   if (diagnosticsEnabled) {

--- a/src/tasks/auto-initiate.test.ts
+++ b/src/tasks/auto-initiate.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TaskStore } from "./store.js";
+import {
+  deriveOracle,
+  maybeInitiateGoal,
+  summarizeGoal,
+  type GoalInitiationDeps,
+} from "./auto-initiate.js";
+
+const TRIVIAL = "what time is it?";
+const LARGE =
+  "Refactor the auth module across all three packages, add tests for each, " +
+  "then migrate the session store, and finally open a PR with the changes.";
+
+// Minimal fake store: captures createTask inputs and returns a task with an id.
+// (*.test.ts is excluded from the project typecheck, so a partial cast is fine.)
+function fakeStore() {
+  const created: Array<Record<string, unknown>> = [];
+  const store = {
+    create: (input: Record<string, unknown>) => {
+      const task = { id: `task-${created.length + 1}`, status: "pending", ...input };
+      created.push(input);
+      return task;
+    },
+  } as unknown as TaskStore;
+  return { store, created };
+}
+
+function deps(over: Partial<GoalInitiationDeps> = {}): GoalInitiationDeps {
+  return {
+    judgeCall: null,
+    capacity: () => ({ ok: true }),
+    ...over,
+  };
+}
+
+describe("maybeInitiateGoal - inline path", () => {
+  it("returns inline for a trivial prompt without touching the store", async () => {
+    const { store, created } = fakeStore();
+    const d = await maybeInitiateGoal({ prompt: TRIVIAL }, deps({ store }));
+    expect(d.mode).toBe("inline");
+    expect(created).toHaveLength(0);
+  });
+});
+
+describe("maybeInitiateGoal - goal path", () => {
+  it("creates a task for a large multi-step prompt and returns ack + first slice", async () => {
+    const { store, created } = fakeStore();
+    const d = await maybeInitiateGoal(
+      { prompt: LARGE, agentSessionKey: "sess-1" },
+      deps({ store }),
+    );
+    expect(d.mode).toBe("task");
+    if (d.mode !== "task") return;
+    expect(created).toHaveLength(1);
+    expect(d.taskId).toBe("task-1");
+    expect(d.ack).toContain(d.taskId);
+    expect(d.ack.toLowerCase()).toContain("just answer"); // opt-out surfaced
+    expect(d.firstSlice).toContain(d.taskId);
+    expect(d.firstSlice.toLowerCase()).toContain("done criteria");
+  });
+
+  it("pins the complexity verdict, oracle kind, and session key into task metadata", async () => {
+    const { store, created } = fakeStore();
+    await maybeInitiateGoal({ prompt: LARGE, agentSessionKey: "sess-9" }, deps({ store }));
+    const input = created[0];
+    expect(input.agentSessionKey).toBe("sess-9");
+    expect(input.source).toBe("user");
+    const meta = input.metadata as Record<string, unknown>;
+    expect(meta.autoInitiated).toBe(true);
+    expect(meta.oracleKind).toBeDefined();
+    expect((meta.complexity as Record<string, unknown>).tier).toBe("goal");
+  });
+});
+
+describe("maybeInitiateGoal - gray band", () => {
+  // LARGE under high cortisol raises thresholds so 0.567 lands in the gray band.
+  const grayDeps = (over: Partial<GoalInitiationDeps>) =>
+    deps({ modulators: { cortisol: 1 }, ...over });
+
+  it("escalates when the judge says GOAL", async () => {
+    const { store, created } = fakeStore();
+    const judge = vi.fn(async () => "GOAL");
+    const d = await maybeInitiateGoal({ prompt: LARGE }, grayDeps({ store, judgeCall: judge }));
+    expect(judge).toHaveBeenCalledTimes(1);
+    expect(d.mode).toBe("task");
+    expect(created).toHaveLength(1);
+  });
+
+  it("stays inline when the judge says INLINE", async () => {
+    const { store, created } = fakeStore();
+    const judge = vi.fn(async () => "INLINE");
+    const d = await maybeInitiateGoal({ prompt: LARGE }, grayDeps({ store, judgeCall: judge }));
+    expect(judge).toHaveBeenCalledTimes(1);
+    expect(d.mode).toBe("inline");
+    expect(created).toHaveLength(0);
+  });
+
+  it("degrades to inline when no judge is registered", async () => {
+    const { store, created } = fakeStore();
+    const d = await maybeInitiateGoal({ prompt: LARGE }, grayDeps({ store, judgeCall: null }));
+    expect(d.mode).toBe("inline");
+    expect(created).toHaveLength(0);
+  });
+
+  it("degrades to inline when the judge throws", async () => {
+    const { store, created } = fakeStore();
+    const judge = vi.fn(async () => {
+      throw new Error("judge unavailable");
+    });
+    const d = await maybeInitiateGoal({ prompt: LARGE }, grayDeps({ store, judgeCall: judge }));
+    expect(d.mode).toBe("inline");
+    expect(created).toHaveLength(0);
+  });
+});
+
+describe("maybeInitiateGoal - backstops", () => {
+  it("defers to inline when at task capacity (no task created)", async () => {
+    const { store, created } = fakeStore();
+    const d = await maybeInitiateGoal(
+      { prompt: LARGE },
+      deps({ store, capacity: () => ({ ok: false, reason: "test full" }) }),
+    );
+    expect(d.mode).toBe("inline");
+    expect(d.reason).toMatch(/capacity/i);
+    expect(created).toHaveLength(0);
+  });
+
+  it("stays inline when no store is available", async () => {
+    const d = await maybeInitiateGoal({ prompt: LARGE }, deps({ store: null }));
+    expect(d.mode).toBe("inline");
+  });
+
+  it("degrades to inline when the store throws on create", async () => {
+    const store = {
+      create: () => {
+        throw new Error("db locked");
+      },
+    } as unknown as TaskStore;
+    const d = await maybeInitiateGoal({ prompt: LARGE }, deps({ store }));
+    expect(d.mode).toBe("inline");
+    expect(d.reason).toMatch(/creation failed/i);
+  });
+});
+
+describe("deriveOracle (mechanical-first, never vacuous)", () => {
+  it("prefers a PR oracle", () => {
+    const o = deriveOracle("do the work and open a PR", "do the work");
+    expect(o.kind).toBe("mechanical");
+    expect(o.doneCriteria.toLowerCase()).toContain("pull request");
+  });
+
+  it("prefers a tests oracle", () => {
+    const o = deriveOracle("add tests for the parser", "add tests for the parser");
+    expect(o.kind).toBe("mechanical");
+    expect(o.doneCriteria.toLowerCase()).toContain("test");
+  });
+
+  it("prefers a files-build oracle when files are referenced", () => {
+    const o = deriveOracle("update src/foo.ts and src/bar.ts", "update files");
+    expect(o.kind).toBe("mechanical");
+    expect(o.doneCriteria.toLowerCase()).toContain("build");
+  });
+
+  it("falls back to a judged oracle that is never empty", () => {
+    const o = deriveOracle(
+      "come up with a strategy for growth",
+      "come up with a strategy for growth",
+    );
+    expect(o.kind).toBe("judged");
+    expect(o.doneCriteria.length).toBeGreaterThan(10);
+  });
+});
+
+describe("summarizeGoal", () => {
+  it("takes the first sentence and bounds the length", () => {
+    expect(summarizeGoal("Do the thing. Then more.")).toBe("Do the thing.");
+    const long = "x".repeat(400);
+    expect(summarizeGoal(long).length).toBeLessThanOrEqual(200);
+  });
+});

--- a/src/tasks/auto-initiate.ts
+++ b/src/tasks/auto-initiate.ts
@@ -1,0 +1,246 @@
+/**
+ * Auto-initiation of goal-oriented workflows (PLAN-22 Phase 2).
+ *
+ * `maybeInitiateGoal` is the single mutating caller of the complexity gate.
+ * It runs the pure Stage-1 appraisal (Phase 1), resolves the gray band via
+ * the temp=0 Judge LLM only when the heuristic is ambiguous, applies the
+ * hormonal concurrency backstop, derives a done-criteria oracle, and (when
+ * warranted) creates the durable Task. It returns a discriminated decision
+ * the gateway hook (Phase 3) consumes: either stay inline, or escalate and
+ * thread an ack + first slice into the run.
+ *
+ * Everything external is injectable so this stays unit-testable without a
+ * live gateway: the task store, the Judge call, the concurrency evaluator,
+ * the affective modulators, and the clock are all seams that default to the
+ * real singletons.
+ *
+ * Failure policy: any error degrades to inline. Auto-initiation must never
+ * block or break a turn (PLAN-22 Addendum item 1).
+ */
+
+import type { TaskSource } from "./types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { acquireTaskSlot, releaseTaskSlot } from "./active-task-tracker.js";
+import {
+  appraiseComplexity,
+  type ComplexityModulators,
+  type ComplexityVerdict,
+} from "./complexity.js";
+import { getJudgeLlmCall, type LlmCall } from "./judge.js";
+import { getActiveTaskStore, type TaskStore } from "./store.js";
+
+const log = createSubsystemLogger("tasks/auto-initiate");
+
+export interface GoalInitiationContext {
+  /** The inbound user prompt (post attachment normalization). */
+  prompt: string;
+  /** Owning agent session key, pinned onto the created task. */
+  agentSessionKey?: string | null;
+  /** Defaults to "user". */
+  source?: TaskSource;
+}
+
+export interface GoalInitiationDeps {
+  /** Affective modulators for threshold modulation. Defaults to neutral. */
+  modulators?: ComplexityModulators;
+  /** Task store seam. Defaults to the registered singleton. */
+  store?: TaskStore | null;
+  /** Judge LLM call for gray-band resolution. Defaults to the registered call. */
+  judgeCall?: LlmCall | null;
+  /** Capacity backstop. Defaults to the hormonal-gated task-slot probe. */
+  capacity?: () => { ok: boolean; reason?: string };
+}
+
+export type OracleKind = "mechanical" | "judged";
+
+export type GoalDecision =
+  | { mode: "inline"; reason: string; verdict: ComplexityVerdict }
+  | {
+      mode: "task";
+      taskId: string;
+      ack: string;
+      firstSlice: string;
+      oracleKind: OracleKind;
+      verdict: ComplexityVerdict;
+    };
+
+const JUDGE_SYSTEM =
+  "You triage whether a user request warrants a structured, multi-step goal " +
+  "workflow (a durable task with checkpoints) versus a single inline answer. " +
+  'Answer with exactly one word: "GOAL" if it is a substantial multi-step ' +
+  'piece of work, or "INLINE" if a single response suffices.';
+
+/** Collapse a prompt into a short goal title (first sentence, bounded). */
+export function summarizeGoal(prompt: string): string {
+  const firstLine = prompt.trim().split(/\n+/)[0] ?? prompt.trim();
+  const sentence = firstLine.split(/(?<=[.!?])\s/)[0] ?? firstLine;
+  const clean = sentence.trim();
+  return clean.length > 200 ? `${clean.slice(0, 197).trimEnd()}...` : clean;
+}
+
+/**
+ * Derive a done-criteria oracle, preferring a mechanical/observable check
+ * over an LLM-judged one. Never returns a vacuous criterion.
+ */
+export function deriveOracle(
+  prompt: string,
+  goal: string,
+): { doneCriteria: string; kind: OracleKind } {
+  if (/\bopen(?:ing)? a (?:pr|pull request)\b/i.test(prompt)) {
+    return {
+      doneCriteria: "A pull request is opened containing the requested changes.",
+      kind: "mechanical",
+    };
+  }
+  if (
+    /\b(?:add|write|with|run)\s+(?:the\s+)?tests?\b/i.test(prompt) ||
+    /tests?\s+pass/i.test(prompt)
+  ) {
+    return { doneCriteria: "The new or updated tests pass.", kind: "mechanical" };
+  }
+  if (/\b[\w./-]+\.(?:ts|tsx|js|jsx|py|rs|go|md|json|sql|css|swift)\b/.test(prompt)) {
+    return {
+      doneCriteria:
+        "The referenced files are updated and the project still builds (typecheck + lint clean).",
+      kind: "mechanical",
+    };
+  }
+  return { doneCriteria: `The stated goal is fully satisfied: ${goal}`, kind: "judged" };
+}
+
+function buildAck(taskId: string, goal: string): string {
+  return (
+    `I've started a goal-oriented task for this (id ${taskId}) because it looks multi-step: "${goal}". ` +
+    `I'll work it in checkpoints and report progress. Reply "just answer" if you'd rather I skip the plan and respond inline.`
+  );
+}
+
+function buildFirstSlice(taskId: string, goal: string, doneCriteria: string): string {
+  return (
+    `You are now working on long-horizon task ${taskId}.\n` +
+    `Goal: ${goal}\n` +
+    `Done criteria: ${doneCriteria}\n` +
+    `Begin with the first concrete step. Use the task_* tools to record a handoff and schedule a wakeup ` +
+    `before you run low on context, so the work survives across turns.`
+  );
+}
+
+/**
+ * Resolve a gray-band prompt via the Judge. Returns true to escalate.
+ * Conservative on every failure path: no judge, malformed answer, or a
+ * thrown error all degrade to "do not escalate".
+ */
+async function resolveGrayBand(prompt: string, judgeCall: LlmCall | null): Promise<boolean> {
+  if (!judgeCall) {
+    log.debug("gray band but no judge call registered -> inline");
+    return false;
+  }
+  try {
+    const answer = await judgeCall(
+      `${JUDGE_SYSTEM}\n\nRequest:\n${prompt}\n\nAnswer with one word:`,
+    );
+    const escalate = /\bgoal\b/i.test(answer) && !/\binline\b/i.test(answer);
+    log.debug(`gray band judged -> ${escalate ? "goal" : "inline"}`);
+    return escalate;
+  } catch (err) {
+    log.debug(
+      `gray-band judge failed (degrading to inline): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Default capacity backstop: probe the hormonal-gated task-slot tracker and
+ * release immediately. Returns whether a new task wakeup could currently run.
+ */
+function defaultCapacity(): { ok: boolean; reason?: string } {
+  const probeId = "auto-initiate:probe";
+  const res = acquireTaskSlot({ jobId: probeId });
+  if (res.ok) {
+    releaseTaskSlot(probeId);
+  }
+  return { ok: res.ok, reason: res.reason };
+}
+
+/**
+ * The single mutating entry point. Appraise the prompt and, when warranted,
+ * create a Task and return the escalation payload; otherwise return inline.
+ */
+export async function maybeInitiateGoal(
+  ctx: GoalInitiationContext,
+  deps: GoalInitiationDeps = {},
+): Promise<GoalDecision> {
+  const verdict = appraiseComplexity(ctx.prompt, deps.modulators ?? {});
+
+  if (verdict.tier === "inline") {
+    return { mode: "inline", reason: "below complexity threshold", verdict };
+  }
+
+  if (verdict.tier === "gray") {
+    const escalate = await resolveGrayBand(ctx.prompt, deps.judgeCall ?? getJudgeLlmCall());
+    if (!escalate) {
+      return { mode: "inline", reason: "gray band resolved to inline", verdict };
+    }
+  }
+
+  // Escalating: apply the hormonal concurrency backstop.
+  const capacity = (deps.capacity ?? defaultCapacity)();
+  if (!capacity.ok) {
+    log.info(`auto-initiation deferred at capacity: ${capacity.reason ?? "at_capacity"}`);
+    return {
+      mode: "inline",
+      reason: `at task capacity (${capacity.reason ?? "at_capacity"})`,
+      verdict,
+    };
+  }
+
+  const store = deps.store ?? getActiveTaskStore();
+  if (!store) {
+    return { mode: "inline", reason: "no task store available", verdict };
+  }
+
+  const goal = summarizeGoal(ctx.prompt);
+  const oracle = deriveOracle(ctx.prompt, goal);
+
+  let taskId: string;
+  try {
+    const task = store.create({
+      goal,
+      doneCriteria: oracle.doneCriteria,
+      source: ctx.source ?? "user",
+      agentSessionKey: ctx.agentSessionKey ?? null,
+      metadata: {
+        autoInitiated: true,
+        oracleKind: oracle.kind,
+        complexity: {
+          score: verdict.score,
+          tier: verdict.tier,
+          thresholds: verdict.thresholds,
+          signals: verdict.signals,
+          reasons: verdict.reasons,
+        },
+        modulators: deps.modulators ?? {},
+      },
+    });
+    taskId = task.id;
+  } catch (err) {
+    log.debug(
+      `task creation failed (degrading to inline): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { mode: "inline", reason: "task creation failed", verdict };
+  }
+
+  log.info(
+    `auto-initiated task ${taskId} (score=${verdict.score.toFixed(3)} tier=${verdict.tier} oracle=${oracle.kind})`,
+  );
+
+  return {
+    mode: "task",
+    taskId,
+    ack: buildAck(taskId, goal),
+    firstSlice: buildFirstSlice(taskId, goal, oracle.doneCriteria),
+    oracleKind: oracle.kind,
+    verdict,
+  };
+}

--- a/src/tasks/complexity.test.ts
+++ b/src/tasks/complexity.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  appraiseComplexity,
+  modulateThresholds,
+  scorePrompt,
+  type ComplexityModulators,
+} from "./complexity.js";
+
+const TRIVIAL = "what time is it?";
+const SMALL_TALK = "thanks, that looks great";
+const LARGE =
+  "Refactor the auth module across all three packages, add tests for each, " +
+  "then migrate the session store, and finally open a PR with the changes.";
+
+describe("scorePrompt (Stage-1 heuristic)", () => {
+  it("is pure: identical input yields identical output", () => {
+    const a = scorePrompt(LARGE);
+    const b = scorePrompt(LARGE);
+    expect(a).toEqual(b);
+  });
+
+  it("scores trivial prompts low and large multi-step prompts high", () => {
+    expect(scorePrompt(TRIVIAL).score).toBeLessThan(0.35);
+    expect(scorePrompt(LARGE).score).toBeGreaterThanOrEqual(0.52);
+  });
+
+  it("keeps the score within [0,1]", () => {
+    const huge = LARGE.repeat(20);
+    const s = scorePrompt(huge).score;
+    expect(s).toBeGreaterThanOrEqual(0);
+    expect(s).toBeLessThanOrEqual(1);
+  });
+
+  it("surfaces contributing signals and reasons", () => {
+    const { signals, reasons } = scorePrompt(LARGE);
+    expect(signals.actionVerbs).toBeGreaterThan(0);
+    expect(signals.artifactHints).toBeGreaterThan(0);
+    expect(reasons.length).toBeGreaterThan(0);
+  });
+});
+
+describe("false-positive guard: long-but-simple prompts", () => {
+  it("does not push a large pasted code block into the goal tier", () => {
+    const codeBlock = "```ts\n" + "const x = 1;\n".repeat(120) + "```";
+    const prompt = `here is the error, what's wrong?\n${codeBlock}`;
+    const v = appraiseComplexity(prompt);
+    expect(v.signals.pastedFraction).toBeGreaterThan(0.5);
+    expect(v.tier).not.toBe("goal");
+  });
+
+  it("discounts a pasted log dump", () => {
+    const log = Array.from(
+      { length: 80 },
+      (_, i) => `2026-05-31T10:00:${String(i % 60).padStart(2, "0")}Z [ERROR] boom ${i}`,
+    ).join("\n");
+    const prompt = `why is this happening?\n${log}`;
+    const v = appraiseComplexity(prompt);
+    expect(v.signals.pastedFraction).toBeGreaterThan(0.5);
+    expect(v.tier).not.toBe("goal");
+  });
+});
+
+describe("modulateThresholds", () => {
+  it("raises thresholds under high cortisol (more conservative)", () => {
+    const base = modulateThresholds({});
+    const stressed = modulateThresholds({ cortisol: 1 });
+    expect(stressed.low).toBeGreaterThan(base.low);
+    expect(stressed.high).toBeGreaterThan(base.high);
+  });
+
+  it("lowers thresholds under high dopamine/curiosity (more eager)", () => {
+    const base = modulateThresholds({});
+    const eager = modulateThresholds({ dopamine: 1, curiosity: 1 });
+    expect(eager.low).toBeLessThan(base.low);
+    expect(eager.high).toBeLessThan(base.high);
+  });
+
+  it("never crosses the rails regardless of saturated input", () => {
+    const extremes: ComplexityModulators[] = [
+      { cortisol: 1, dopamine: 0, curiosity: 0 },
+      { cortisol: 0, dopamine: 1, curiosity: 1 },
+      { cortisol: 1, dopamine: 1, curiosity: 1 },
+    ];
+    for (const mod of extremes) {
+      const { low, high } = modulateThresholds(mod);
+      expect(low).toBeGreaterThanOrEqual(0.2);
+      expect(low).toBeLessThanOrEqual(0.45);
+      expect(high).toBeGreaterThanOrEqual(0.48);
+      expect(high).toBeLessThanOrEqual(0.78);
+      expect(low).toBeLessThan(high);
+    }
+  });
+
+  it("treats omitted modulators as neutral baseline", () => {
+    expect(modulateThresholds({})).toEqual(
+      modulateThresholds({ cortisol: 0, dopamine: 0, curiosity: 0 }),
+    );
+  });
+});
+
+describe("appraiseComplexity (tiering)", () => {
+  it("routes trivial -> inline", () => {
+    expect(appraiseComplexity(TRIVIAL).tier).toBe("inline");
+    expect(appraiseComplexity(SMALL_TALK).tier).toBe("inline");
+  });
+
+  it("routes large multi-step -> goal", () => {
+    expect(appraiseComplexity(LARGE).tier).toBe("goal");
+  });
+
+  it("flags the gray band with needsLlm and resolves it nowhere here", () => {
+    // A prompt engineered to land between the thresholds.
+    const mid = "refactor the login handler and add a test";
+    const v = appraiseComplexity(mid);
+    if (v.tier === "gray") {
+      expect(v.needsLlm).toBe(true);
+    } else {
+      // If weighting drifts, at least assert needsLlm tracks the tier.
+      expect(v.needsLlm).toBe(false);
+    }
+  });
+
+  it("needsLlm is true iff tier is gray", () => {
+    for (const p of [TRIVIAL, SMALL_TALK, LARGE, "refactor the login handler and add a test"]) {
+      const v = appraiseComplexity(p);
+      expect(v.needsLlm).toBe(v.tier === "gray");
+    }
+  });
+
+  it("high cortisol can pull a borderline prompt down out of the goal tier", () => {
+    const borderline = "add a feature flag and write a test for it";
+    const calm = appraiseComplexity(borderline, { dopamine: 1, curiosity: 1 });
+    const stressed = appraiseComplexity(borderline, { cortisol: 1 });
+    // Eager state should never be a higher tier than stressed state.
+    const order = { inline: 0, gray: 1, goal: 2 } as const;
+    expect(order[stressed.tier]).toBeLessThanOrEqual(order[calm.tier]);
+  });
+});

--- a/src/tasks/complexity.ts
+++ b/src/tasks/complexity.ts
@@ -1,0 +1,273 @@
+/**
+ * Prompt complexity appraisal (PLAN-22 Phase 1, Affective Goal Drive).
+ *
+ * Pure, side-effect-free Stage-1 of the FrugalGPT-style cascade described
+ * in PLAN-22. Given an inbound user prompt and (optionally) a snapshot of
+ * the affective modulators, it produces a {@link ComplexityVerdict}: a raw
+ * heuristic score in [0,1], the (hormonally modulated) decision thresholds,
+ * and a tier of `inline` / `gray` / `goal`.
+ *
+ * The gray band is deliberately *not* resolved here - it returns
+ * `needsLlm: true` so the caller (Phase 2 `auto-initiate`) can consult the
+ * temp=0 Judge only when the cheap heuristic is genuinely ambiguous. The
+ * common trivial and obviously-large cases never pay for an LLM round-trip.
+ *
+ * Design invariants (asserted by the tests):
+ *   - The scorer is pure: same input -> same output, no I/O, no clock.
+ *   - Modulation shifts the *thresholds*, never the raw text score, and the
+ *     shifted thresholds are clamped to fixed rails so behaviour stays
+ *     bounded and testable regardless of hormonal state.
+ *   - A long-but-simple prompt (a pasted log or fenced code block) must not
+ *     be pushed into the goal tier by sheer length: prose length, not raw
+ *     length, drives the length signal. (PLAN-22 Addendum item 4.)
+ */
+
+export type ComplexityTier = "inline" | "gray" | "goal";
+
+/**
+ * Affective modulators consumed by threshold modulation. Kept minimal and
+ * decoupled from `HormonalState` on purpose so this module stays pure and
+ * trivially testable; Phase 2 adapts the live snapshot into this shape.
+ * All fields are 0..1; omitted fields are treated as the neutral baseline.
+ */
+export interface ComplexityModulators {
+  /** Stress/threat. High cortisol narrows scope: raises the thresholds. */
+  cortisol?: number;
+  /** Reward/novelty. High dopamine lowers the thresholds (more eager). */
+  dopamine?: number;
+  /** GCCRF curiosity drive. High curiosity lowers the thresholds. */
+  curiosity?: number;
+}
+
+/** Cheap textual features extracted from the prompt. */
+export interface ComplexitySignals {
+  /** Prose character count (excludes fenced code / pasted-log lines). */
+  proseChars: number;
+  /** Count of imperative/action verbs (implement, refactor, deploy, ...). */
+  actionVerbs: number;
+  /** Sequencing markers ("then", "after that", "first", numbered steps). */
+  sequencingMarkers: number;
+  /** Conjoined or enumerated sub-requests ("and", bullets, numbered list). */
+  enumerationItems: number;
+  /** Multi-deliverable / cross-cutting artifact hints (PR, tests, across packages). */
+  artifactHints: number;
+  /** Fraction of the prompt that is fenced code or log-like, 0..1. */
+  pastedFraction: number;
+}
+
+export interface ComplexityVerdict {
+  tier: ComplexityTier;
+  /** Raw heuristic score from the text alone, 0..1. */
+  score: number;
+  /** Decision thresholds after hormonal modulation (clamped to rails). */
+  thresholds: { low: number; high: number };
+  /** True iff `tier === "gray"`: the caller should resolve via the Judge. */
+  needsLlm: boolean;
+  signals: ComplexitySignals;
+  /** Human-readable contributors, for telemetry and debuggability. */
+  reasons: string[];
+}
+
+// --- Tunables (deterministic; tests assert against these) ---------------
+
+/** Baseline gray band: score < low -> inline; score >= high -> goal. */
+const BASE_LOW = 0.35;
+const BASE_HIGH = 0.52;
+
+/** Hard rails. Modulation may move thresholds only within these bounds. */
+const RAIL_LOW_MIN = 0.2;
+const RAIL_LOW_MAX = 0.45;
+const RAIL_HIGH_MIN = 0.48;
+const RAIL_HIGH_MAX = 0.78;
+
+/** Max threshold shift contributed by a fully saturated modulator. */
+const MOD_SHIFT = 0.12;
+
+/** Length at which the prose-length signal saturates to 1.0. */
+const LENGTH_SATURATION_CHARS = 600;
+
+/** Feature weights for the raw score (pre-clamp). */
+const W = {
+  length: 0.3,
+  actionVerbs: 0.22,
+  sequencing: 0.18,
+  enumeration: 0.18,
+  artifacts: 0.22,
+} as const;
+
+const ACTION_VERB_RE =
+  /\b(implement|build|create|add|refactor|fix|migrate|design|investigate|analy[sz]e|integrate|rewrite|port|deploy|set\s?up|configure|generate|write|review|audit|optimi[sz]e|debug|test|plan|research|compare|evaluate|wire|extract)\b/gi;
+
+const SEQUENCING_RE =
+  /\b(then|after that|afterwards|next|first(?:ly)?|second(?:ly)?|third(?:ly)?|finally|lastly|once .* (?:is|are) done|before you|followed by)\b/gi;
+
+/** "across all three packages", "end to end", "open a PR", "with tests", etc. */
+const ARTIFACT_RE =
+  /\b(across (?:all|every|the)|end[- ]to[- ]end|open a (?:pr|pull request)|with tests?|add tests?|all (?:three|four|\d+|the) (?:packages|services|modules|files)|each (?:package|service|module)|multiple files|whole (?:codebase|repo|repository)|every (?:file|module))\b/gi;
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function countMatches(text: string, re: RegExp): number {
+  const m = text.match(re);
+  return m ? m.length : 0;
+}
+
+/**
+ * Strip fenced code blocks and pasted-log lines so that a long quoted blob
+ * does not masquerade as a complex multi-step request. Returns the prose
+ * remainder and the fraction of the original that was stripped.
+ */
+function separateProse(prompt: string): { prose: string; pastedFraction: number } {
+  const total = prompt.length || 1;
+  let stripped = 0;
+
+  // Fenced code blocks (``` ... ```), including unterminated trailing fences.
+  let prose = prompt.replace(/```[\s\S]*?(?:```|$)/g, (block) => {
+    stripped += block.length;
+    return " ";
+  });
+
+  // Log-like lines: ISO timestamps, [LEVEL] tags, or stack-trace "at " frames.
+  prose = prose
+    .split("\n")
+    .filter((line) => {
+      const isLogLike =
+        /^\s*\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(line) ||
+        /^\s*(?:\[)?(?:ERROR|WARN|INFO|DEBUG|TRACE|FATAL)\b/i.test(line) ||
+        /^\s*at\s+\S+\s+\(/.test(line);
+      if (isLogLike) {
+        stripped += line.length + 1;
+        return false;
+      }
+      return true;
+    })
+    .join("\n");
+
+  return { prose, pastedFraction: clamp(stripped / total, 0, 1) };
+}
+
+/**
+ * Stage-1 heuristic scorer. Pure: derives a raw [0,1] complexity score and
+ * the contributing signals from the prompt text alone.
+ */
+export function scorePrompt(prompt: string): {
+  score: number;
+  signals: ComplexitySignals;
+  reasons: string[];
+} {
+  const { prose, pastedFraction } = separateProse(prompt);
+  const proseChars = prose.trim().length;
+
+  const actionVerbs = countMatches(prose, ACTION_VERB_RE);
+  const sequencingMarkers = countMatches(prose, SEQUENCING_RE);
+
+  // Enumeration: bullet/numbered list markers plus clause-joining "and".
+  const listMarkers = countMatches(prose, /^\s*(?:[-*]|\d+[.)])\s+/gm);
+  const andJoins = countMatches(prose, /\b and \b/gi);
+  const enumerationItems = listMarkers + andJoins;
+
+  const artifactHints = countMatches(prose, ARTIFACT_RE);
+
+  const lengthScore = clamp(proseChars / LENGTH_SATURATION_CHARS, 0, 1);
+  const verbScore = clamp(actionVerbs / 4, 0, 1);
+  const seqScore = clamp(sequencingMarkers / 3, 0, 1);
+  const enumScore = clamp(enumerationItems / 4, 0, 1);
+  const artifactScore = clamp(artifactHints / 2, 0, 1);
+
+  const raw =
+    lengthScore * W.length +
+    verbScore * W.actionVerbs +
+    seqScore * W.sequencing +
+    enumScore * W.enumeration +
+    artifactScore * W.artifacts;
+
+  const score = clamp(raw, 0, 1);
+
+  const reasons: string[] = [];
+  if (lengthScore > 0)
+    reasons.push(`prose_length=${proseChars} (+${(lengthScore * W.length).toFixed(2)})`);
+  if (actionVerbs > 0)
+    reasons.push(`action_verbs=${actionVerbs} (+${(verbScore * W.actionVerbs).toFixed(2)})`);
+  if (sequencingMarkers > 0)
+    reasons.push(`sequencing=${sequencingMarkers} (+${(seqScore * W.sequencing).toFixed(2)})`);
+  if (enumerationItems > 0)
+    reasons.push(`enumeration=${enumerationItems} (+${(enumScore * W.enumeration).toFixed(2)})`);
+  if (artifactHints > 0)
+    reasons.push(`artifacts=${artifactHints} (+${(artifactScore * W.artifacts).toFixed(2)})`);
+  if (pastedFraction > 0.25)
+    reasons.push(`pasted_fraction=${pastedFraction.toFixed(2)} (length discounted)`);
+
+  return {
+    score,
+    signals: {
+      proseChars,
+      actionVerbs,
+      sequencingMarkers,
+      enumerationItems,
+      artifactHints,
+      pastedFraction,
+    },
+    reasons,
+  };
+}
+
+/**
+ * Modulate the decision thresholds by affective state. High cortisol raises
+ * the thresholds (be conservative: fewer goals under stress); high dopamine
+ * and curiosity lower them (be eager: start goals, decompose deeper). The
+ * result is clamped to fixed rails so behaviour stays bounded.
+ */
+export function modulateThresholds(mod: ComplexityModulators = {}): { low: number; high: number } {
+  const cortisol = clamp(mod.cortisol ?? 0, 0, 1);
+  const dopamine = clamp(mod.dopamine ?? 0, 0, 1);
+  const curiosity = clamp(mod.curiosity ?? 0, 0, 1);
+
+  // Positive shift = more conservative (higher thresholds).
+  const eagerness = (dopamine + curiosity) / 2;
+  const shift = (cortisol - eagerness) * MOD_SHIFT;
+
+  const low = clamp(BASE_LOW + shift, RAIL_LOW_MIN, RAIL_LOW_MAX);
+  const high = clamp(BASE_HIGH + shift, RAIL_HIGH_MIN, RAIL_HIGH_MAX);
+  return { low, high };
+}
+
+/**
+ * Full Stage-1 appraisal: score the text, modulate the thresholds by
+ * affective state, and assign a tier. The gray band returns
+ * `needsLlm: true` for the caller to resolve.
+ */
+export function appraiseComplexity(
+  prompt: string,
+  mod: ComplexityModulators = {},
+): ComplexityVerdict {
+  const { score, signals, reasons } = scorePrompt(prompt);
+  const thresholds = modulateThresholds(mod);
+
+  let tier: ComplexityTier;
+  if (score < thresholds.low) {
+    tier = "inline";
+  } else if (score >= thresholds.high) {
+    tier = "goal";
+  } else {
+    tier = "gray";
+  }
+
+  const modReasons: string[] = [];
+  if (mod.cortisol != null) modReasons.push(`cortisol=${mod.cortisol.toFixed(2)}`);
+  if (mod.dopamine != null) modReasons.push(`dopamine=${mod.dopamine.toFixed(2)}`);
+  if (mod.curiosity != null) modReasons.push(`curiosity=${mod.curiosity.toFixed(2)}`);
+  if (modReasons.length > 0) {
+    modReasons.push(`-> thresholds [${thresholds.low.toFixed(2)}, ${thresholds.high.toFixed(2)}]`);
+  }
+
+  return {
+    tier,
+    score,
+    thresholds,
+    needsLlm: tier === "gray",
+    signals,
+    reasons: [...reasons, ...modReasons],
+  };
+}

--- a/src/tasks/zeigarnik.test.ts
+++ b/src/tasks/zeigarnik.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeZeigarnikTension,
+  maybeResumeFromTension,
+  type ZeigarnikTask,
+  type ZeigarnikTension,
+} from "./zeigarnik.js";
+
+const NOW = 1_000_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function task(over: Partial<ZeigarnikTask> = {}): ZeigarnikTask {
+  return { status: "pending", createdAt: NOW - HOUR, lastSeenAt: NOW - HOUR, ...over };
+}
+
+describe("computeZeigarnikTension", () => {
+  it("is zero when there are no tasks", () => {
+    const t = computeZeigarnikTension({ tasks: [], now: NOW });
+    expect(t.tension).toBe(0);
+    expect(t.pendingCount).toBe(0);
+  });
+
+  it("ignores terminal tasks", () => {
+    const t = computeZeigarnikTension({
+      tasks: [
+        task({ status: "completed" }),
+        task({ status: "failed" }),
+        task({ status: "stopped" }),
+      ],
+      now: NOW,
+    });
+    expect(t.pendingCount).toBe(0);
+    expect(t.tension).toBe(0);
+  });
+
+  it("rises with the number of open tasks", () => {
+    const few = computeZeigarnikTension({ tasks: [task()], now: NOW });
+    const many = computeZeigarnikTension({ tasks: [task(), task(), task(), task()], now: NOW });
+    expect(many.tension).toBeGreaterThan(few.tension);
+    expect(many.pendingCount).toBe(4);
+  });
+
+  it("rises with age and stall", () => {
+    const fresh = computeZeigarnikTension({
+      tasks: [task({ createdAt: NOW - HOUR, lastSeenAt: NOW - HOUR })],
+      now: NOW,
+    });
+    const stale = computeZeigarnikTension({
+      tasks: [task({ createdAt: NOW - DAY, lastSeenAt: NOW - 12 * HOUR })],
+      now: NOW,
+    });
+    expect(stale.tension).toBeGreaterThan(fresh.tension);
+    expect(stale.oldestAgeMs).toBe(DAY);
+  });
+
+  it("stays within [0,1] even when saturated", () => {
+    const tasks = Array.from({ length: 20 }, () =>
+      task({ createdAt: NOW - 10 * DAY, lastSeenAt: NOW - 10 * DAY }),
+    );
+    const t = computeZeigarnikTension({ tasks, now: NOW, hormonal: { cortisol: 1 } });
+    expect(t.tension).toBeGreaterThan(0);
+    expect(t.tension).toBeLessThanOrEqual(1);
+  });
+
+  it("cortisol amplifies and dopamine dampens tension", () => {
+    const base = computeZeigarnikTension({ tasks: [task(), task()], now: NOW });
+    const stressed = computeZeigarnikTension({
+      tasks: [task(), task()],
+      now: NOW,
+      hormonal: { cortisol: 1 },
+    });
+    const driven = computeZeigarnikTension({
+      tasks: [task(), task()],
+      now: NOW,
+      hormonal: { dopamine: 1 },
+    });
+    expect(stressed.tension).toBeGreaterThan(base.tension);
+    expect(driven.tension).toBeLessThan(base.tension);
+  });
+});
+
+describe("maybeResumeFromTension", () => {
+  const high: ZeigarnikTension = {
+    tension: 0.8,
+    pendingCount: 3,
+    oldestAgeMs: DAY,
+    maxStallMs: 12 * HOUR,
+    contributors: [],
+  };
+  const low: ZeigarnikTension = { ...high, tension: 0.2 };
+
+  it("resumes when tension is above threshold and not throttled", () => {
+    const d = maybeResumeFromTension({ tension: high, now: NOW });
+    expect(d.resume).toBe(true);
+  });
+
+  it("does not resume below threshold", () => {
+    const d = maybeResumeFromTension({ tension: low, now: NOW });
+    expect(d.resume).toBe(false);
+    expect(d.reason).toMatch(/below/);
+  });
+
+  it("respects the throttle window", () => {
+    const d = maybeResumeFromTension({ tension: high, now: NOW, lastResumeAt: NOW - 60_000 });
+    expect(d.resume).toBe(false);
+    expect(d.reason).toMatch(/throttled/);
+  });
+
+  it("resumes once the throttle window has elapsed", () => {
+    const d = maybeResumeFromTension({ tension: high, now: NOW, lastResumeAt: NOW - 10 * 60_000 });
+    expect(d.resume).toBe(true);
+  });
+
+  it("decays (does not resume) when dismissed", () => {
+    const d = maybeResumeFromTension({ tension: high, now: NOW, dismissed: true });
+    expect(d.resume).toBe(false);
+    expect(d.reason).toMatch(/dismissed/);
+  });
+
+  it("does not resume when there are no open tasks", () => {
+    const none: ZeigarnikTension = { ...high, pendingCount: 0, tension: 0 };
+    const d = maybeResumeFromTension({ tension: none, now: NOW });
+    expect(d.resume).toBe(false);
+  });
+});

--- a/src/tasks/zeigarnik.ts
+++ b/src/tasks/zeigarnik.ts
@@ -1,0 +1,151 @@
+/**
+ * Zeigarnik tension adapters (PLAN-22 Phase 4).
+ *
+ * The Zeigarnik effect: unfinished tasks occupy memory and create resumption
+ * pressure. These pure adapters quantify that pressure from the set of open
+ * tasks and decide, under a throttle, whether the system should proactively
+ * resume one. The dream engine and proactive recall consume `tension` to bias
+ * toward resolving open loops; that consumer wiring is tracked as a follow-up
+ * (this module is intentionally pure and side-effect-free so it can be wired
+ * into either consumer without change).
+ *
+ * Everything here is pure: no clock, no I/O. Callers pass `now`.
+ */
+
+import { isTerminal, type TaskStatus } from "./types.js";
+
+/** The minimal task shape the tension calculation needs. */
+export interface ZeigarnikTask {
+  status: TaskStatus;
+  createdAt: number;
+  lastSeenAt: number;
+}
+
+export interface ZeigarnikModulators {
+  /** Stress amplifies the nag of open loops. */
+  cortisol?: number;
+  /** Reward/drive slightly dampens rumination on the backlog. */
+  dopamine?: number;
+}
+
+export interface ZeigarnikInput {
+  tasks: ZeigarnikTask[];
+  now: number;
+  hormonal?: ZeigarnikModulators;
+}
+
+export interface ZeigarnikTension {
+  /** Aggregate resumption pressure, 0..1. */
+  tension: number;
+  /** Number of open (non-terminal) tasks. */
+  pendingCount: number;
+  /** Age of the oldest open task, ms. */
+  oldestAgeMs: number;
+  /** Longest time any open task has gone untouched (stall), ms. */
+  maxStallMs: number;
+  contributors: string[];
+}
+
+// Saturation points for the raw signals.
+const COUNT_SATURATION = 5; // 5+ open tasks saturates the count term
+const AGE_SATURATION_MS = 24 * 60 * 60 * 1000; // 1 day
+const STALL_SATURATION_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+const W = { count: 0.4, age: 0.25, stall: 0.35 } as const;
+
+// Hormonal amplification rails: tension can be scaled within [MIN, MAX].
+const AMP_MIN = 0.8;
+const AMP_MAX = 1.25;
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+/**
+ * Compute aggregate Zeigarnik tension from the open-task set. Pure.
+ */
+export function computeZeigarnikTension(input: ZeigarnikInput): ZeigarnikTension {
+  const open = input.tasks.filter((t) => !isTerminal(t.status));
+  const pendingCount = open.length;
+
+  if (pendingCount === 0) {
+    return { tension: 0, pendingCount: 0, oldestAgeMs: 0, maxStallMs: 0, contributors: [] };
+  }
+
+  const ages = open.map((t) => Math.max(0, input.now - t.createdAt));
+  const stalls = open.map((t) => Math.max(0, input.now - t.lastSeenAt));
+  const oldestAgeMs = Math.max(...ages);
+  const maxStallMs = Math.max(...stalls);
+
+  const countScore = clamp(pendingCount / COUNT_SATURATION, 0, 1);
+  const ageScore = clamp(oldestAgeMs / AGE_SATURATION_MS, 0, 1);
+  const stallScore = clamp(maxStallMs / STALL_SATURATION_MS, 0, 1);
+
+  const base = countScore * W.count + ageScore * W.age + stallScore * W.stall;
+
+  // Hormonal amplification: cortisol raises tension, dopamine eases it.
+  const cortisol = clamp(input.hormonal?.cortisol ?? 0, 0, 1);
+  const dopamine = clamp(input.hormonal?.dopamine ?? 0, 0, 1);
+  const amp = clamp(1 + 0.25 * cortisol - 0.2 * dopamine, AMP_MIN, AMP_MAX);
+
+  const tension = clamp(base * amp, 0, 1);
+
+  const contributors: string[] = [
+    `pending=${pendingCount} (+${(countScore * W.count).toFixed(2)})`,
+    `oldestAgeMs=${oldestAgeMs} (+${(ageScore * W.age).toFixed(2)})`,
+    `maxStallMs=${maxStallMs} (+${(stallScore * W.stall).toFixed(2)})`,
+  ];
+  if (cortisol > 0 || dopamine > 0) {
+    contributors.push(
+      `amp=${amp.toFixed(2)} (cortisol=${cortisol.toFixed(2)} dopamine=${dopamine.toFixed(2)})`,
+    );
+  }
+
+  return { tension, pendingCount, oldestAgeMs, maxStallMs, contributors };
+}
+
+export interface ResumeDecisionInput {
+  tension: ZeigarnikTension;
+  now: number;
+  /** Tension at/above which a resume is warranted. Default 0.5. */
+  threshold?: number;
+  /** Timestamp of the last tension-driven resume, for throttling. */
+  lastResumeAt?: number | null;
+  /** Minimum gap between tension-driven resumes. Default 5 minutes. */
+  minIntervalMs?: number;
+  /** When the user has dismissed the nudge: decay (do not resume). */
+  dismissed?: boolean;
+}
+
+export interface ResumeDecision {
+  resume: boolean;
+  reason: string;
+}
+
+const DEFAULT_THRESHOLD = 0.5;
+const DEFAULT_MIN_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Decide whether to proactively resume an open task from tension. Pure.
+ * Respects a throttle and decays on user dismissal.
+ */
+export function maybeResumeFromTension(input: ResumeDecisionInput): ResumeDecision {
+  if (input.dismissed) {
+    return { resume: false, reason: "dismissed (decaying)" };
+  }
+  if (input.tension.pendingCount === 0) {
+    return { resume: false, reason: "no open tasks" };
+  }
+  const minInterval = input.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  if (input.lastResumeAt != null && input.now - input.lastResumeAt < minInterval) {
+    return { resume: false, reason: "throttled" };
+  }
+  const threshold = input.threshold ?? DEFAULT_THRESHOLD;
+  if (input.tension.tension < threshold) {
+    return {
+      resume: false,
+      reason: `tension ${input.tension.tension.toFixed(2)} below ${threshold}`,
+    };
+  }
+  return { resume: true, reason: `tension ${input.tension.tension.toFixed(2)} >= ${threshold}` };
+}


### PR DESCRIPTION
## Summary

Implements PLAN-22 (Affective Goal Drive): the agent appraises inbound prompt complexity and, when warranted, automatically initiates a goal-oriented workflow, with escalation thresholds modulated by live hormonal state. Built on the PLAN-16/17 long-horizon task spine. Design doc: `docs/plans/PLAN-22-affective-goal-drive.md`.

Delivers the core capability end to end behind feature flags. **Phases 0-4 complete and verified; Phase 5 (`task_resume_inline`) deferred.**

## What landed

- **Phase 0 - fail-closed pre-turn seam** (`src/gateway/server-methods/pre-turn-decision.ts`): `applyPreTurnDecision` runs in the agent handler after the client ack and before the `agentCommand` dispatch. A registered decider may augment only `message` + `extraSystemPrompt`; no decider / throw / 800ms timeout / malformed result all degrade to the unmodified payload. Default no-op = zero behaviour change.
- **Phase 1 - pure complexity appraisal** (`src/tasks/complexity.ts`): heuristic scorer + hormonal threshold modulation (shifts thresholds not the score, clamped to rails). Prose-length signal excludes fenced code / pasted logs so a long-but-simple prompt is never pushed into the goal tier.
- **Phase 2 - auto-initiate caller** (`src/tasks/auto-initiate.ts`): `maybeInitiateGoal` - appraise, resolve gray band via temp=0 Judge only when ambiguous, hormonal capacity backstop, mechanical-first done-criteria oracle, create the Task with verdict + modulators in metadata. Every failure degrades to inline.
- **Phase 3 - register the gate** (`src/gateway/server-methods/auto-initiate-decider.ts`, wired in `server.impl.ts`): `BITTERBOT_TASKS_COMPLEXITY_GATE` (default on) = appraise + log telemetry only; `BITTERBOT_TASKS_AUTO_INITIATE` (default off) = create the Task and thread first slice + user-facing ack/opt-out into `extraSystemPrompt`. `/new` and `/reset` never reach the seam.
- **Phase 4 - Zeigarnik tension adapters** (`src/tasks/zeigarnik.ts`): pure `computeZeigarnikTension` (open-task count/age/stall, cortisol-amplified, dopamine-damped, clamped) + `maybeResumeFromTension` (throttled, decays on dismissal).

## Verification

- `pnpm tsgo`: **0 errors** (confirmed across two independent runs).
- `pnpm exec vitest run src/tasks/ src/gateway/server-methods/`: full suite green (new tests plus the existing gateway suite; no regressions).
- `oxfmt` + `oxlint`: clean.

## Deviations from the plan (corrected against real code)

- `TaskStore` create method is `create(input)`, not `createTask` (caught by tsgo).
- The plan's `server-impl-tasks.ts` does not exist; registration wired into the real `src/gateway/server.impl.ts` (after `startHormonalAccessor`).
- `event-journal.ts` does not back task events; decision audit is via task `metadata` + subsystem logger.
- Capacity via `acquireTaskSlot`/`releaseTaskSlot` probe; store via `getActiveTaskStore`; Judge `LlmCall` is single-arg.
- P0.1 narrowed to the seam itself (no full `dispatchAgentRun` extraction) to avoid regression risk on the message hot path with no new behaviour gained.
- Phase 4 is a standalone module (not appended to `biology.ts`); dream/recall consumer wiring is a follow-up.

## Deferred: Phase 5 (`task_resume_inline`)

Requires extracting the shared `buildResumeMessage` + cross-wakeup session/auth carry from `task_schedule_wakeup` (P0.2) and adding the tool in the 1280-line `task-tool.ts` - the plan's flagged riskiest item. Scoped as a follow-up.

## Rollout

Off or telemetry-only by default. Recommended: run with `COMPLEXITY_GATE` on / `AUTO_INITIATE` off to collect gate precision/recall telemetry before enabling task creation via `BITTERBOT_TASKS_AUTO_INITIATE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
