### PR TITLE
feat(tasks): PLAN-22 enable auto-initiation by default

### DIFF
--- a/docs/automation/long-horizon-tasks.md
+++ b/docs/automation/long-horizon-tasks.md
@@ -235,28 +235,29 @@ When a task is auto-initiated, the acknowledgement tells the user how to
 opt out for that turn (reply "just answer" to get an inline response
 instead of a plan).
 
-Both behaviours are gated by env flags and are conservative by default:
+Both behaviours are gated by env flags, both on by default:
 
-- With only `BITTERBOT_TASKS_COMPLEXITY_GATE` on (the default), the gate
-  runs in **telemetry mode**: it appraises and logs, but never creates a
-  task or alters the run. This is the recommended first step, to observe
-  what would be escalated before enabling it.
-- Set `BITTERBOT_TASKS_AUTO_INITIATE=1` to let the gate actually create
-  tasks and brief the run.
+- `BITTERBOT_TASKS_COMPLEXITY_GATE` (on by default) controls whether the
+  gate runs at all. Set to `0` to disable appraisal entirely.
+- `BITTERBOT_TASKS_AUTO_INITIATE` (on by default) controls whether the
+  gate actually creates a task and briefs the run. Set to `0` (or
+  `false`) to keep the gate in **telemetry mode**: it still appraises and
+  logs, but never creates a task or alters the run. Use this if you want
+  to observe what would be escalated before letting it act.
 
 Once a task is created, it flows through the same handoff, wakeup, and
 Judge machinery described above.
 
 ## Configuration
 
-| Env var                           | Default                             | Effect                                                                              |
-| --------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
-| `BITTERBOT_EVENT_JOURNAL`         | `1` (on)                            | Set to `0` to disable the event journal                                             |
-| `BITTERBOT_EVENT_JOURNAL_DB`      | `~/.bitterbot/event-journal.sqlite` | Journal DB path                                                                     |
-| `BITTERBOT_TASKS_DB`              | `~/.bitterbot/tasks.sqlite`         | Task store DB path                                                                  |
-| `BITTERBOT_TASKS_MAX_WAKEUPS`     | `50`                                | Per-task wakeup cap (runaway-loop guard)                                            |
-| `BITTERBOT_TASKS_COMPLEXITY_GATE` | `1` (on)                            | Appraise prompt complexity per turn (telemetry only). Set to `0` to disable.        |
-| `BITTERBOT_TASKS_AUTO_INITIATE`   | `0` (off)                           | Let the complexity gate auto-create a task and brief the run. Set to `1` to enable. |
+| Env var                           | Default                             | Effect                                                                                       |
+| --------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| `BITTERBOT_EVENT_JOURNAL`         | `1` (on)                            | Set to `0` to disable the event journal                                                      |
+| `BITTERBOT_EVENT_JOURNAL_DB`      | `~/.bitterbot/event-journal.sqlite` | Journal DB path                                                                              |
+| `BITTERBOT_TASKS_DB`              | `~/.bitterbot/tasks.sqlite`         | Task store DB path                                                                           |
+| `BITTERBOT_TASKS_MAX_WAKEUPS`     | `50`                                | Per-task wakeup cap (runaway-loop guard)                                                     |
+| `BITTERBOT_TASKS_COMPLEXITY_GATE` | `1` (on)                            | Appraise prompt complexity per turn (telemetry only). Set to `0` to disable.                 |
+| `BITTERBOT_TASKS_AUTO_INITIATE`   | `1` (on)                            | Let the complexity gate auto-create a task and brief the run. Set to `0` for telemetry-only. |
 
 ## Verification: end-to-end test plan
 

--- a/src/gateway/server-methods/auto-initiate-decider.test.ts
+++ b/src/gateway/server-methods/auto-initiate-decider.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PreTurnContext, PreTurnPayload } from "./pre-turn-decision.js";
-import { buildAutoInitiationDecider } from "./auto-initiate-decider.js";
+import {
+  buildAutoInitiationDecider,
+  isAutoInitiateEnabled,
+  isComplexityGateEnabled,
+} from "./auto-initiate-decider.js";
 
 const CTX: PreTurnContext = { sessionKey: "s1", agentId: "a1", runId: "r1", channel: "web" };
 const BASE: PreTurnPayload = {
@@ -17,6 +21,37 @@ const taskDecision = {
   verdict: {} as never,
 };
 const inlineDecision = { mode: "inline" as const, reason: "below", verdict: {} as never };
+
+describe("env flag defaults", () => {
+  const prev = {
+    gate: process.env.BITTERBOT_TASKS_COMPLEXITY_GATE,
+    auto: process.env.BITTERBOT_TASKS_AUTO_INITIATE,
+  };
+  afterEach(() => {
+    if (prev.gate === undefined) delete process.env.BITTERBOT_TASKS_COMPLEXITY_GATE;
+    else process.env.BITTERBOT_TASKS_COMPLEXITY_GATE = prev.gate;
+    if (prev.auto === undefined) delete process.env.BITTERBOT_TASKS_AUTO_INITIATE;
+    else process.env.BITTERBOT_TASKS_AUTO_INITIATE = prev.auto;
+  });
+
+  it("complexity gate is on by default and off only when set to 0", () => {
+    delete process.env.BITTERBOT_TASKS_COMPLEXITY_GATE;
+    expect(isComplexityGateEnabled()).toBe(true);
+    process.env.BITTERBOT_TASKS_COMPLEXITY_GATE = "0";
+    expect(isComplexityGateEnabled()).toBe(false);
+  });
+
+  it("auto-initiate is on by default and off only when explicitly disabled", () => {
+    delete process.env.BITTERBOT_TASKS_AUTO_INITIATE;
+    expect(isAutoInitiateEnabled()).toBe(true);
+    process.env.BITTERBOT_TASKS_AUTO_INITIATE = "1";
+    expect(isAutoInitiateEnabled()).toBe(true);
+    process.env.BITTERBOT_TASKS_AUTO_INITIATE = "0";
+    expect(isAutoInitiateEnabled()).toBe(false);
+    process.env.BITTERBOT_TASKS_AUTO_INITIATE = "false";
+    expect(isAutoInitiateEnabled()).toBe(false);
+  });
+});
 
 describe("buildAutoInitiationDecider", () => {
   it("is a no-op when both flags are off", async () => {

--- a/src/gateway/server-methods/auto-initiate-decider.ts
+++ b/src/gateway/server-methods/auto-initiate-decider.ts
@@ -8,8 +8,9 @@
  * Two env flags gate behaviour:
  *   - BITTERBOT_TASKS_COMPLEXITY_GATE (default ON): appraise + log telemetry
  *     only. No task is created and the payload is never mutated.
- *   - BITTERBOT_TASKS_AUTO_INITIATE (default OFF): actually create the Task
+ *   - BITTERBOT_TASKS_AUTO_INITIATE (default ON): actually create the Task
  *     and augment the run's extraSystemPrompt with the first slice + ack.
+ *     Set to "0"/"false" to fall back to appraisal-only telemetry.
  *
  * The decider only ever augments `extraSystemPrompt`; combined with the
  * seam's fail-closed wrapper, it cannot block or alter the run on any
@@ -29,10 +30,10 @@ export function isComplexityGateEnabled(): boolean {
   return process.env.BITTERBOT_TASKS_COMPLEXITY_GATE !== "0";
 }
 
-/** Actual task creation, off by default. Enable with "1" / "true". */
+/** Actual task creation, on by default. Disable with "0" / "false". */
 export function isAutoInitiateEnabled(): boolean {
   const v = process.env.BITTERBOT_TASKS_AUTO_INITIATE;
-  return v === "1" || v === "true";
+  return v !== "0" && v !== "false";
 }
 
 /**


### PR DESCRIPTION
Flips `BITTERBOT_TASKS_AUTO_INITIATE` to **on by default** (opt-out via `0`/`false`), so the PLAN-22 complexity gate creates tasks and briefs the run out of the box.

## Change
- `isAutoInitiateEnabled()`: now `v !== "0" && v !== "false"` (was `v === "1" || v === "true"`), matching the `COMPLEXITY_GATE` flag pattern.
- Module doc comment + `docs/automation/long-horizon-tasks.md` (prose + Configuration table) updated to reflect on-by-default.
- 2 new tests asserting both flag defaults and their off-switches.

## Behaviour after this change (verified at runtime)
- No env set → gate on, auto-initiate on: a multi-step prompt creates a task and augments the run's system prompt with the first slice + a "reply 'just answer' to skip" opt-out; the user message is untouched.
- `BITTERBOT_TASKS_AUTO_INITIATE=0` (or `false`) → telemetry-only: appraise + log, no task, no mutation.
- Per-turn user opt-out ("just answer") and the fail-closed seam (throw/timeout/malformed → unmodified payload) are unchanged.

## Heads-up
This **overrides PLAN-22's addendum recommendation** to keep auto-initiation opt-in until gate precision/recall telemetry is reviewed. Flipped at owner request.

## Verification
- `pnpm tsgo`: 0 errors
- 58 PLAN-22 tests pass; `oxlint` clean; `docs-link-audit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)