### PR TITLE
chore: add issue templates (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report something that is not working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections below so we can reproduce and fix it quickly.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you do? Numbered steps are ideal.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages and logs if available.
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Tell us about your setup.
+      value: |
+        - OS:
+        - Node version:
+        - Install method (source build / release binary / other):
+        - App version / commit:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Bitterbot-AI/bitterbot-desktop/blob/main/SECURITY.md
+    about: Please do not file security vulnerabilities as public issues. Follow the disclosure process in SECURITY.md instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please describe the problem before the solution so we can understand what you are trying to achieve.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What is frustrating or missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have thought about, and why they fall short.
+    validations:
+      required: false


### PR DESCRIPTION
Adds the issue templates requested in #15.

- `.github/ISSUE_TEMPLATE/bug_report.yml` — description, steps to reproduce, expected vs actual, environment (OS, Node version, install method, version/commit)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem, proposal, alternatives considered
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false` plus a contact link routing security reports to SECURITY.md so vuln reports don't get filed publicly by accident

Disabling blank issues also prevents the kind of empty submission seen in #55.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)