### PR TITLE
fix(x402): harden payment verification (replay window, single-use race, testnet default)

### DIFF
--- a/src/gateway/a2a/payment.ts
+++ b/src/gateway/a2a/payment.ts
@@ -86,7 +86,11 @@ export async function verifyA2aPayment(
       return { paid: false };
     }
 
-    const network = config.tools?.wallet?.network ?? "base-sepolia";
+    // Default the verification network to mainnet. Defaulting to a testnet here
+    // is fail-open: if payments are enabled but tools.wallet.network is unset,
+    // the paywall could be satisfied with valueless base-sepolia USDC. Fail
+    // closed onto mainnet so a missing config never downgrades to testnet money.
+    const network = config.tools?.wallet?.network ?? "base";
 
     const verification = await verifyX402Payment({
       paymentToken: paymentToken ?? paymentHeader!,

--- a/src/services/x402-verify.test.ts
+++ b/src/services/x402-verify.test.ts
@@ -304,15 +304,14 @@ describe("verifyX402Payment", () => {
     setReceipt("0xreplay");
     const db = new DatabaseSync(":memory:");
     db.exec(`
-      CREATE TABLE marketplace_purchases (
+      CREATE TABLE x402_consumed_tx (
         tx_hash TEXT PRIMARY KEY,
-        amount_usdc REAL,
-        purchased_at INTEGER
+        consumed_at INTEGER NOT NULL
       )
     `);
     db.prepare(
-      "INSERT INTO marketplace_purchases (tx_hash, amount_usdc, purchased_at) VALUES (?, ?, ?)",
-    ).run("0xreplay", 0.05, Date.now());
+      "INSERT INTO x402_consumed_tx (tx_hash, consumed_at) VALUES (?, ?)",
+    ).run("0xreplay", Date.now());
     const r = await verifyX402Payment({
       paymentToken: encodeToken({
         txHash: "0xreplay",
@@ -327,5 +326,91 @@ describe("verifyX402Payment", () => {
     });
     expect(r.valid).toBe(false);
     expect(r.error).toMatch(/already consumed/);
+  });
+
+  it("requires a timestamp — token omitting it is rejected (F1: expiry bypass)", async () => {
+    setReceipt("0xnots");
+    const r = await verifyX402Payment({
+      // No `timestamp` field at all. Pre-fix this skipped the expiry check and
+      // an unsigned token was accepted, allowing replay of an old transfer.
+      paymentToken: encodeToken({ txHash: "0xnots", amount: 0.05, sender }),
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+    });
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/missing required timestamp/i);
+  });
+
+  it("rejects a token timestamped in the future (F1: pre-dating)", async () => {
+    setReceipt("0xfuture");
+    const r = await verifyX402Payment({
+      paymentToken: encodeToken({
+        txHash: "0xfuture",
+        amount: 0.05,
+        sender,
+        timestamp: Date.now() + 10 * 60 * 1000,
+      }),
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+    });
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/future/i);
+  });
+
+  it("atomically consumes tx_hash on success — second verify is rejected (F2: TOCTOU)", async () => {
+    setReceipt("0xonce");
+    const db = new DatabaseSync(":memory:");
+    // No table pre-created: verify creates x402_consumed_tx on first use.
+    const token = encodeToken({
+      txHash: "0xonce",
+      amount: 0.05,
+      sender,
+      timestamp: Date.now(),
+    });
+    const first = await verifyX402Payment({
+      paymentToken: token,
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+      db,
+    });
+    const second = await verifyX402Payment({
+      paymentToken: token,
+      expectedRecipient: recipient,
+      minimumAmount: 0.01,
+      network: "base",
+      db,
+    });
+    expect(first.valid).toBe(true);
+    expect(second.valid).toBe(false);
+    expect(second.error).toMatch(/already consumed/);
+    const rows = db.prepare("SELECT COUNT(*) c FROM x402_consumed_tx").get() as { c: number };
+    expect(rows.c).toBe(1);
+  });
+
+  it("only one of N concurrent verifies of the same token wins (F2: atomic claim)", async () => {
+    setReceipt("0xrace");
+    const db = new DatabaseSync(":memory:");
+    db.exec(`CREATE TABLE x402_consumed_tx (tx_hash TEXT PRIMARY KEY, consumed_at INTEGER NOT NULL)`);
+    const token = encodeToken({
+      txHash: "0xrace",
+      amount: 0.05,
+      sender,
+      timestamp: Date.now(),
+    });
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        verifyX402Payment({
+          paymentToken: token,
+          expectedRecipient: recipient,
+          minimumAmount: 0.01,
+          network: "base",
+          db,
+        }),
+      ),
+    );
+    expect(results.filter((r) => r.valid).length).toBe(1);
   });
 });

--- a/src/services/x402-verify.ts
+++ b/src/services/x402-verify.ts
@@ -28,6 +28,40 @@ import { canonicalizePaymentPayload } from "./a2a-client.js";
 
 const log = createSubsystemLogger("x402-verify");
 
+/**
+ * Atomically claim a tx_hash for single-use enforcement.
+ *
+ * Creates the ledger table on first use, then attempts an INSERT. Returns true
+ * if this call won the claim (row inserted), false if the tx_hash was already
+ * consumed (UNIQUE constraint violation). This is the race-free authority for
+ * single-use: even under N concurrent verifications of the same token, the DB's
+ * UNIQUE constraint guarantees exactly one INSERT succeeds.
+ */
+function claimTxHashAtomically(
+  db: import("node:sqlite").DatabaseSync,
+  txHash: string,
+): boolean {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS x402_consumed_tx (
+       tx_hash TEXT PRIMARY KEY,
+       consumed_at INTEGER NOT NULL
+     )`,
+  );
+  try {
+    db.prepare(`INSERT INTO x402_consumed_tx (tx_hash, consumed_at) VALUES (?, ?)`).run(
+      txHash,
+      Date.now(),
+    );
+    return true;
+  } catch (err) {
+    // UNIQUE/PRIMARY KEY violation => another request already consumed this tx.
+    if (err instanceof Error && /UNIQUE|constraint/i.test(err.message)) {
+      return false;
+    }
+    throw err;
+  }
+}
+
 // Canonical USDC contract addresses on Base. Pinning these here lets us reject
 // Transfer events emitted by attacker-deployed fake tokens — without this, a
 // recipient-matching Transfer from any contract would pass verification.
@@ -89,9 +123,20 @@ export async function verifyX402Payment(params: {
       return { valid: false, error: `Amount ${amount} below minimum ${params.minimumAmount}` };
     }
 
-    // Replay protection: transaction must be within 5 minutes
-    if (decoded.timestamp && Date.now() - decoded.timestamp > 5 * 60 * 1000) {
+    // Replay protection: every token MUST carry a timestamp and fall within the
+    // 5-minute window. Previously this was `if (decoded.timestamp && ...)`, so a
+    // token that simply OMITTED `timestamp` skipped the expiry check entirely —
+    // letting an attacker replay an old on-chain transfer indefinitely on the
+    // unsigned path. Require the field unconditionally and fail closed.
+    if (typeof decoded.timestamp !== "number" || !Number.isFinite(decoded.timestamp)) {
+      return { valid: false, error: "Payment token missing required timestamp" };
+    }
+    if (Date.now() - decoded.timestamp > 5 * 60 * 1000) {
       return { valid: false, error: "Payment token expired" };
+    }
+    // Reject tokens dated in the future (clock-skew / pre-dating abuse).
+    if (decoded.timestamp - Date.now() > 60 * 1000) {
+      return { valid: false, error: "Payment token timestamp is in the future" };
     }
 
     // Verify the signed binding when present. The signature proves the buyer's
@@ -135,13 +180,23 @@ export async function verifyX402Payment(params: {
     }
 
     // Single-use enforcement — reject already-consumed payment tokens.
-    // Without this, a valid payment can be replayed thousands of times within the
-    // 5-minute window. (Gemini peer review: replay attack fix)
-    // The UNIQUE index on tx_hash in marketplace_purchases enforces this at the DB level.
+    // This cheap pre-check rejects obvious replays early, but it is NOT the
+    // authority: a SELECT here followed by an INSERT later in the caller is a
+    // check-then-act (TOCTOU) gap that two concurrent requests can both pass.
+    // The authoritative, race-free claim happens after all checks succeed, via
+    // claimTxHashAtomically() below (atomic INSERT into a dedicated ledger).
     if (params.db) {
-      const existing = params.db
-        .prepare(`SELECT 1 FROM marketplace_purchases WHERE tx_hash = ?`)
-        .get(decoded.txHash);
+      // The ledger table may not exist yet on a fresh DB; it is created lazily
+      // by claimTxHashAtomically(). A missing table simply means "nothing
+      // consumed yet", so tolerate it here rather than throwing.
+      let existing: unknown;
+      try {
+        existing = params.db
+          .prepare(`SELECT 1 FROM x402_consumed_tx WHERE tx_hash = ?`)
+          .get(decoded.txHash.toLowerCase());
+      } catch {
+        existing = undefined;
+      }
       if (existing) {
         return { valid: false, error: "Payment token already consumed" };
       }
@@ -210,6 +265,21 @@ export async function verifyX402Payment(params: {
       }
     } catch (err) {
       return { valid: false, error: `On-chain verification failed: ${String(err)}` };
+    }
+
+    // Authoritative single-use claim. All verification has passed; now atomically
+    // record the tx_hash so that no other concurrent request can also succeed.
+    // This closes the TOCTOU window left by the SELECT-only pre-check above: the
+    // UNIQUE constraint on x402_consumed_tx means exactly one of N concurrent
+    // verifications of the same token wins the INSERT; the rest fail and are
+    // reported as already consumed. The dedicated ledger is used (rather than
+    // marketplace_purchases) because verify does not yet know the skill/buyer/
+    // amount columns that table requires NOT NULL at purchase-record time.
+    if (params.db) {
+      const claimed = claimTxHashAtomically(params.db, decoded.txHash.toLowerCase());
+      if (!claimed) {
+        return { valid: false, error: "Payment token already consumed" };
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary

Hardens the x402 marketplace payment verification path against three issues found during a security review of `main`. All three sit in `verifyX402Payment` and its caller.

### 1. Unsigned tokens could skip the 5-minute expiry window
`src/services/x402-verify.ts` enforced the replay window only when a `timestamp` was present (`if (decoded.timestamp && ...)`). An unsigned legacy token that simply **omitted** `timestamp` skipped the check entirely, so an old on-chain transfer to the recipient could be replayed as a fresh payment indefinitely.

**Fix:** require `timestamp` unconditionally (fail closed when missing) and also reject tokens dated in the future.

### 2. Single-use was non-atomic (TOCTOU)
Verification only did a read-only `SELECT` and left the `INSERT` to the caller — a check-then-act gap two concurrent requests could both pass, letting one payment back multiple redemptions within the 5-minute window.

**Fix:** add an authoritative, race-free claim. After all checks pass, `verifyX402Payment` does an atomic `INSERT` into a dedicated `x402_consumed_tx` ledger; the `UNIQUE` constraint guarantees exactly one of N concurrent verifications wins. The cheap pre-check `SELECT` is kept (now tolerant of the table not existing yet). A dedicated ledger is used rather than `marketplace_purchases` because verify doesn't yet know that table's `NOT NULL` skill/buyer/amount columns at verify time.

### 3. Verification network defaulted to testnet
`src/gateway/a2a/payment.ts` defaulted to `base-sepolia` when `tools.wallet.network` was unset, so a common misconfiguration let the paywall be satisfied with valueless testnet USDC.

**Fix:** default to `base` (mainnet) — fail closed onto real money.

## Tests
Added regression tests in `x402-verify.test.ts`:
- timestamp required (omitted → rejected)
- future-dated token rejected
- single-use: second verify of a consumed token rejected
- atomic claim: only 1 of 8 concurrent verifies of the same token succeeds

**Verification run locally:**
- 17/17 `x402-verify.test.ts` pass
- 79/79 across the payment-path suites (a2a-client, gateway/a2a, status tool, pipeline digest) pass
- `oxlint` and `tsgo --noEmit` clean on changed files

## Note
Reported privately to security@bitterbot.net per SECURITY.md; opening this PR as the suggested fix. Happy to adjust the ledger approach (e.g. fold the claim into an existing migration) if you prefer a different table/migration convention.
