### PR TITLE
feat(models): add Atlas Cloud provider

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -291,6 +291,10 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("HUGGINGFACE_HUB_TOKEN") ?? pick("HF_TOKEN");
   }
 
+  if (normalized === "atlascloud") {
+    return pick("ATLASCLOUD_API_KEY") ?? pick("ATLAS_CLOUD_API_KEY");
+  }
+
   const envMap: Record<string, string> = {
     openai: "OPENAI_API_KEY",
     google: "GEMINI_API_KEY",

--- a/src/agents/models-config.e2e-harness.ts
+++ b/src/agents/models-config.e2e-harness.ts
@@ -49,6 +49,8 @@ export function unsetEnv(vars: string[]) {
 }
 
 export const MODELS_CONFIG_IMPLICIT_ENV_VARS = [
+  "ATLASCLOUD_API_KEY",
+  "ATLAS_CLOUD_API_KEY",
   "CLOUDFLARE_AI_GATEWAY_API_KEY",
   "COPILOT_GITHUB_TOKEN",
   "GH_TOKEN",

--- a/src/agents/models-config.providers.atlascloud.test.ts
+++ b/src/agents/models-config.providers.atlascloud.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveApiKeyForProvider } from "./model-auth.js";
+import {
+  ATLASCLOUD_BASE_URL,
+  buildAtlasCloudProvider,
+  resolveImplicitProviders,
+} from "./models-config.providers.js";
+
+const ATLAS_ENV_VARS = ["ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"];
+
+describe("Atlas Cloud provider", () => {
+  it.each(ATLAS_ENV_VARS)("includes atlascloud when %s is configured", async (envVar) => {
+    const agentDir = mkdtempSync(join(tmpdir(), "bitterbot-test-"));
+    const envSnapshot = captureEnv(ATLAS_ENV_VARS);
+    delete process.env.ATLASCLOUD_API_KEY;
+    delete process.env.ATLAS_CLOUD_API_KEY;
+    process.env[envVar] = "atlascloud-test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.atlascloud).toMatchObject({
+        apiKey: envVar,
+        baseUrl: ATLASCLOUD_BASE_URL,
+        api: "openai-completions",
+      });
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("does not include atlascloud without a key", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "bitterbot-test-"));
+    const envSnapshot = captureEnv(ATLAS_ENV_VARS);
+    delete process.env.ATLASCLOUD_API_KEY;
+    delete process.env.ATLAS_CLOUD_API_KEY;
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.atlascloud).toBeUndefined();
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("resolves the preferred Atlas Cloud environment variable", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "bitterbot-test-"));
+    const envSnapshot = captureEnv(ATLAS_ENV_VARS);
+    process.env.ATLASCLOUD_API_KEY = "preferred-key";
+    process.env.ATLAS_CLOUD_API_KEY = "fallback-key";
+
+    try {
+      const auth = await resolveApiKeyForProvider({ provider: "atlascloud", agentDir });
+      expect(auth.apiKey).toBe("preferred-key");
+      expect(auth.source).toContain("ATLASCLOUD_API_KEY");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
+  it("builds the OpenAI-compatible Atlas Cloud model catalog", () => {
+    const provider = buildAtlasCloudProvider();
+    expect(provider.baseUrl).toBe("https://api.atlascloud.ai/v1");
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "deepseek-ai/deepseek-v4-pro",
+      "deepseek-ai/deepseek-v4-flash",
+      "qwen/qwen3.5-27b",
+    ]);
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -50,6 +50,16 @@ const MINIMAX_API_COST = {
 
 type ProviderModelConfig = NonNullable<ProviderConfig["models"]>[number];
 
+export const ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1";
+const ATLASCLOUD_DEFAULT_CONTEXT_WINDOW = 1_048_000;
+const ATLASCLOUD_DEFAULT_MAX_TOKENS = 393_000;
+const ATLASCLOUD_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 function buildMinimaxModel(params: {
   id: string;
   name: string;
@@ -484,6 +494,42 @@ function buildMoonshotProvider(): ProviderConfig {
   };
 }
 
+export function buildAtlasCloudProvider(): ProviderConfig {
+  return {
+    baseUrl: ATLASCLOUD_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: "deepseek-ai/deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+        reasoning: false,
+        input: ["text"],
+        cost: ATLASCLOUD_DEFAULT_COST,
+        contextWindow: ATLASCLOUD_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: ATLASCLOUD_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "deepseek-ai/deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        reasoning: false,
+        input: ["text"],
+        cost: ATLASCLOUD_DEFAULT_COST,
+        contextWindow: ATLASCLOUD_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: ATLASCLOUD_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "qwen/qwen3.5-27b",
+        name: "Qwen3.5 27B",
+        reasoning: true,
+        input: ["text"],
+        cost: ATLASCLOUD_DEFAULT_COST,
+        contextWindow: 262_000,
+        maxTokens: 65_000,
+      },
+    ],
+  };
+}
+
 function buildQwenPortalProvider(): ProviderConfig {
   return {
     baseUrl: QWEN_PORTAL_BASE_URL,
@@ -674,6 +720,13 @@ export async function resolveImplicitProviders(params: {
   const authStore = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
   });
+
+  const atlasCloudKey =
+    resolveEnvApiKeyVarName("atlascloud") ??
+    resolveApiKeyFromProfiles({ provider: "atlascloud", store: authStore });
+  if (atlasCloudKey) {
+    providers.atlascloud = { ...buildAtlasCloudProvider(), apiKey: atlasCloudKey };
+  }
 
   const minimaxKey =
     resolveEnvApiKeyVarName("minimax") ??


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an implicit OpenAI-compatible model provider
- resolve credentials from `ATLASCLOUD_API_KEY` with `ATLAS_CLOUD_API_KEY` as a fallback
- register DeepSeek V4 Pro, DeepSeek V4 Flash, and Qwen3.5 27B model presets
- cover provider injection, credential precedence, and catalog metadata with focused tests

The provider reuses the existing `openai-completions` runtime and defaults to `https://api.atlascloud.ai/v1`.

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec vitest run src/agents/models-config.providers.atlascloud.test.ts` (5 passed)
- `corepack pnpm exec oxfmt --check ...`
- `corepack pnpm tsgo`
- `corepack pnpm lint` (0 warnings/errors)
- `corepack pnpm build`
- `git diff --check`
- Atlas Cloud live `/v1/models` catalog: 121 models; all three configured IDs confirmed

The build completed successfully and retained the prebuilt A2UI bundle because A2UI sources are not present in this checkout.

## Documentation

No README, documentation, logo, sponsor, credits, or partner changes.