### PR TITLE
fix(docker): make the image build, ship the served UI, and prove it in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,3 +54,7 @@ vendor/
 !vendor/a2ui/renderers/
 !vendor/a2ui/renderers/lit/
 !vendor/a2ui/renderers/lit/**
+
+# The renderer's public assets are needed for the Control UI build; the global
+# image-extension excludes above would silently drop them from the context.
+!desktop/renderer/public/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,33 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: pnpm test:gateway
 
+  docker:
+    # Verifies V1 audit blocker 4: this Dockerfile could not build from the
+    # initial commit until 2026-08-26 and had zero CI coverage, which is how it
+    # stayed broken. The smoke test proves the built image actually boots the
+    # gateway and serves the Control UI, not merely that the layers assemble.
+    name: Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t bitterbot:ci .
+
+      - name: Smoke test — gateway boots and serves the Control UI
+        run: |
+          docker run -d --name bb -p 19001:19001             -e BITTERBOT_GATEWAY_TOKEN=ci-smoke-token             bitterbot:ci             node bitterbot.mjs gateway --allow-unconfigured --bind lan
+          code=000
+          for i in $(seq 1 90); do
+            code=$(curl -s -o /dev/null -w '%{http_code}'               -H "Authorization: Bearer ci-smoke-token"               http://127.0.0.1:19001/ || true)
+            [ "$code" = "200" ] && break
+            sleep 2
+          done
+          echo "GET / -> $code"
+          docker logs bb 2>&1 | tail -30
+          [ "$code" = "200" ]
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# syntax=docker/dockerfile:1.7
-# The syntax line enables `COPY --parents` (manifest copies that keep their
-# directory layout), so the workspace-member list below cannot drift.
-#
 # This file could not build from the initial commit until 2026-08-26: it copied
 # a `ui/` dir and `patches/` that never existed, ran an undefined `pnpm
 # ui:build`, and installed Bun for nothing (V1 audit blocker 4). It is verified
@@ -25,7 +21,19 @@ RUN if [ -n "$BITTERBOT_DOCKER_APT_PACKAGES" ]; then \
 # desktop/ and extensions/* are pnpm workspace members: without their
 # package.json files, `--frozen-lockfile` fails against the workspace lockfile.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY --parents desktop/package.json extensions/*/package.json ./
+COPY desktop/package.json ./desktop/
+# One line per extension, deliberately: `COPY --parents` needs a newer BuildKit
+# than CI's classic builder (and many self-hosters' Docker) provides. If a new
+# extension gains a package.json and is missed here, --frozen-lockfile fails
+# and the CI docker job catches it.
+COPY extensions/discord/package.json ./extensions/discord/
+COPY extensions/google-antigravity-auth/package.json ./extensions/google-antigravity-auth/
+COPY extensions/google-gemini-cli-auth/package.json ./extensions/google-gemini-cli-auth/
+COPY extensions/signal/package.json ./extensions/signal/
+COPY extensions/slack/package.json ./extensions/slack/
+COPY extensions/telegram/package.json ./extensions/telegram/
+COPY extensions/twitch/package.json ./extensions/twitch/
+COPY extensions/whatsapp/package.json ./extensions/whatsapp/
 COPY scripts ./scripts
 
 # postinstall fetches the orchestrator binary. Point it INSIDE the image at the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM node:22-bookworm
+# syntax=docker/dockerfile:1.7
+# The syntax line enables `COPY --parents` (manifest copies that keep their
+# directory layout), so the workspace-member list below cannot drift.
+#
+# This file could not build from the initial commit until 2026-08-26: it copied
+# a `ui/` dir and `patches/` that never existed, ran an undefined `pnpm
+# ui:build`, and installed Bun for nothing (V1 audit blocker 4). It is verified
+# by the docker-build job in CI; keep that job green when touching this file.
 
-# Install Bun (required for build scripts)
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+FROM node:22-bookworm
 
 RUN corepack enable
 
@@ -16,31 +21,38 @@ RUN if [ -n "$BITTERBOT_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
+# Manifests first so the dependency layer only rebuilds when they change.
+# desktop/ and extensions/* are pnpm workspace members: without their
+# package.json files, `--frozen-lockfile` fails against the workspace lockfile.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY ui/package.json ./ui/package.json
-COPY patches ./patches
+COPY --parents desktop/package.json extensions/*/package.json ./
 COPY scripts ./scripts
 
+# postinstall fetches the orchestrator binary. Point it INSIDE the image at the
+# repo-relative path the resolver probes, not the default ~/.bitterbot/bin:
+# HOME is /root during build but the runtime user is `node`, and compose mounts
+# the host config dir over /home/node/.bitterbot, which would shadow anything
+# placed there. Fetch failures are non-fatal by design (the gateway runs
+# isolated without P2P), so an unpublished release does not break the build.
+ENV BITTERBOT_ORCHESTRATOR_INSTALL_DIR=/app/orchestrator/target/release
 RUN pnpm install --frozen-lockfile
 
 COPY . .
+# `pnpm build` includes ui:build since PLAN-39: the gateway serves the Control
+# UI it stages into dist/control-ui, so the image ships the full product on one
+# port with no separate UI process.
 RUN pnpm build
-# Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
-ENV BITTERBOT_PREFER_PNPM=1
-RUN pnpm ui:build
 
 ENV NODE_ENV=production
 
 # Allow non-root user to write temp files during runtime/tests.
 RUN chown -R node:node /app
 
-# Security hardening: Run as non-root user
-# The node:22-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
+# Security hardening: run as the non-root `node` user (uid 1000).
 USER node
 
-# Start gateway server with default config.
-# Binds to loopback (127.0.0.1) by default for security.
+# Start gateway server with default config. Binds to loopback (127.0.0.1) by
+# default for security; the Control UI is served by the gateway at /.
 #
 # For container platforms requiring external health checks:
 #   1. Set BITTERBOT_GATEWAY_TOKEN or BITTERBOT_GATEWAY_PASSWORD env var

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command:
       [
         "node",
-        "dist/index.js",
+        "bitterbot.mjs",
         "gateway",
         "--bind",
         "${BITTERBOT_GATEWAY_BIND:-lan}",
@@ -36,4 +36,4 @@ services:
     stdin_open: true
     tty: true
     init: true
-    entrypoint: ["node", "dist/index.js"]
+    entrypoint: ["node", "bitterbot.mjs"]

--- a/scripts/fetch-orchestrator.mjs
+++ b/scripts/fetch-orchestrator.mjs
@@ -30,7 +30,12 @@ import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 
 const REPO = "Bitterbot-AI/bitterbot-desktop";
-const INSTALL_DIR = join(homedir(), ".bitterbot", "bin");
+// Overridable for container builds: the Docker image fetches into the
+// repo-relative path the resolver probes, because ~/.bitterbot inside a
+// container is either the wrong HOME (root at build time) or shadowed by the
+// compose volume mount at runtime.
+const INSTALL_DIR =
+  process.env.BITTERBOT_ORCHESTRATOR_INSTALL_DIR?.trim() || join(homedir(), ".bitterbot", "bin");
 
 // Resolve the Cargo.toml relative to this script, not cwd — pnpm
 // postinstall can run from nested workspace packages.


### PR DESCRIPTION
Proves the Dockerfile fix (V1 audit blocker 4) via the new CI docker job before it lands on main. Build + boot + serve smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XEh9Pr5czd483ajE3g5NG