### PR TITLE
feat: add HOL Guard before-tool-call plugin

### DIFF
--- a/extensions/hol-guard/bitterbot.plugin.json
+++ b/extensions/hol-guard/bitterbot.plugin.json
@@ -1,0 +1,31 @@
+{
+  "id": "hol-guard",
+  "name": "HOL Guard",
+  "description": "Run HOL Guard before Bitterbot shell commands execute.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "executable": {
+        "type": "string",
+        "default": "hol-guard"
+      },
+      "timeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 30000,
+        "default": 10000
+      }
+    }
+  },
+  "uiHints": {
+    "executable": {
+      "label": "HOL Guard executable",
+      "help": "Path or command name for the HOL Guard CLI."
+    },
+    "timeoutMs": {
+      "label": "Inspection timeout (ms)",
+      "help": "Maximum time to wait for HOL Guard before the command is blocked."
+    }
+  }
+}

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -1,0 +1,119 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { BitterbotPluginApi } from "bitterbot/plugin-sdk";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_EXECUTABLE = "hol-guard";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+type HolGuardPluginConfig = {
+  executable?: string;
+  timeoutMs?: number;
+};
+
+type BeforeToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+};
+
+type BeforeToolCallResult = {
+  block?: boolean;
+  blockReason?: string;
+};
+
+export type GuardInspector = (command: string) => Promise<boolean>;
+
+function resolvePluginConfig(pluginConfig?: Record<string, unknown>) {
+  const cfg = (pluginConfig ?? {}) as HolGuardPluginConfig;
+  const executable =
+    typeof cfg.executable === "string" && cfg.executable.trim()
+      ? cfg.executable.trim()
+      : DEFAULT_EXECUTABLE;
+  const timeoutMs =
+    typeof cfg.timeoutMs === "number" && Number.isFinite(cfg.timeoutMs)
+      ? Math.max(100, Math.min(30_000, Math.trunc(cfg.timeoutMs)))
+      : DEFAULT_TIMEOUT_MS;
+  return { executable, timeoutMs };
+}
+
+async function inspectCommandWithHolGuard(
+  command: string,
+  options: { executable: string; timeoutMs: number },
+): Promise<boolean> {
+  const { stdout } = await execFileAsync(
+    options.executable,
+    ["command", "test", command, "--json"],
+    {
+      encoding: "utf8",
+      timeout: options.timeoutMs,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  const result = JSON.parse(stdout) as {
+    classification?: { explicitly_benign?: boolean };
+    minimum_action?: string;
+  };
+  return result.classification?.explicitly_benign === true && result.minimum_action === "allow";
+}
+
+export function createHolGuardBeforeToolCallHandler(inspect: GuardInspector) {
+  return async (event: BeforeToolCallEvent): Promise<BeforeToolCallResult | void> => {
+    if (event.toolName !== "exec") {
+      return;
+    }
+
+    const command = event.params.command;
+    if (typeof command !== "string" || !command.trim()) {
+      return {
+        block: true,
+        blockReason: "HOL Guard: exec command text is missing or invalid.",
+      };
+    }
+
+    try {
+      if (await inspect(command)) {
+        return;
+      }
+      return {
+        block: true,
+        blockReason: "HOL Guard: command requires review before execution.",
+      };
+    } catch {
+      return {
+        block: true,
+        blockReason: "HOL Guard: command inspection failed.",
+      };
+    }
+  };
+}
+
+const holGuardPlugin = {
+  id: "hol-guard",
+  name: "HOL Guard",
+  description: "Run HOL Guard before Bitterbot shell commands execute.",
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      executable: {
+        type: "string",
+        default: DEFAULT_EXECUTABLE,
+      },
+      timeoutMs: {
+        type: "integer",
+        minimum: 100,
+        maximum: 30_000,
+        default: DEFAULT_TIMEOUT_MS,
+      },
+    },
+  },
+  register(api: BitterbotPluginApi) {
+    const config = resolvePluginConfig(api.pluginConfig);
+    api.on(
+      "before_tool_call",
+      createHolGuardBeforeToolCallHandler((command) => inspectCommandWithHolGuard(command, config)),
+    );
+  },
+};
+
+export default holGuardPlugin;

--- a/src/plugins/hol-guard.plugin.test.ts
+++ b/src/plugins/hol-guard.plugin.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHolGuardBeforeToolCallHandler } from "../../extensions/hol-guard/index.js";
+
+describe("HOL Guard plugin", () => {
+  it("allows exec only when HOL Guard explicitly allows the command", async () => {
+    const inspect = vi.fn().mockResolvedValue(true);
+    const handler = createHolGuardBeforeToolCallHandler(inspect);
+
+    await expect(handler({ toolName: "exec", params: { command: "git status" } })).resolves.toBeUndefined();
+    expect(inspect).toHaveBeenCalledWith("git status");
+  });
+
+  it("blocks exec when HOL Guard does not explicitly allow the command", async () => {
+    const handler = createHolGuardBeforeToolCallHandler(vi.fn().mockResolvedValue(false));
+
+    await expect(handler({ toolName: "exec", params: { command: "rm -rf ./tmp" } })).resolves.toEqual({
+      block: true,
+      blockReason: "HOL Guard: command requires review before execution.",
+    });
+  });
+
+  it("fails closed when HOL Guard inspection errors", async () => {
+    const handler = createHolGuardBeforeToolCallHandler(
+      vi.fn().mockRejectedValue(new Error("guard unavailable")),
+    );
+
+    await expect(handler({ toolName: "exec", params: { command: "npm publish" } })).resolves.toEqual({
+      block: true,
+      blockReason: "HOL Guard: command inspection failed.",
+    });
+  });
+
+  it("blocks malformed exec input and ignores unrelated tools", async () => {
+    const inspect = vi.fn().mockResolvedValue(true);
+    const handler = createHolGuardBeforeToolCallHandler(inspect);
+
+    await expect(handler({ toolName: "exec", params: {} })).resolves.toEqual({
+      block: true,
+      blockReason: "HOL Guard: exec command text is missing or invalid.",
+    });
+    await expect(handler({ toolName: "read", params: { path: "README.md" } })).resolves.toBeUndefined();
+    expect(inspect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a bundled HOL Guard plugin for Bitterbot's existing `before_tool_call` hook.

For `exec` calls it runs `hol-guard command test <command> --json` before the shell command executes. Only an explicitly benign `allow` result proceeds; review/risky results, malformed output, CLI failures, and timeouts block the call. Other tools are unchanged.

The plugin is disabled by default with the other bundled extensions. HOL Guard itself is installed separately with `pipx install hol-guard` and `hol-guard init`.

Includes focused tests for allow, block, malformed input, unrelated tools, and fail-closed errors.